### PR TITLE
Change first argument to `TextInput.OnFocusLost` to `TextBox.Text`

### DIFF
--- a/src/TextInput.lua
+++ b/src/TextInput.lua
@@ -46,9 +46,9 @@ function TextInput:init()
 		self:setState({ Focused = true })
 		self.props.OnFocused()
 	end
-	self.onFocusLost = function(_, enterPressed, inputObject)
+	self.onFocusLost = function(rbx, enterPressed, inputObject)
 		self:setState({ Focused = false })
-		self.props.OnFocusLost(enterPressed, inputObject)
+		self.props.OnFocusLost(rbx.Text, enterPressed, inputObject)
 	end
 	self.onChanged = function(rbx)
 		self.props.OnChanged(rbx.Text)


### PR DESCRIPTION
This PR changes the first argument to `TextInput.OnFocusLost` to `TextBox.Text` (shifting down the other arguments), allowing consumers to easily use `OnFocusLost` for submissions