### PR TITLE
Add position and size properties to dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Dev
 /.vscode
 /roblox.toml
+/plugin
 
 # Docs
 /assets

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Roblox
 /Packages
+/Placefiles
 /*.rbxm
 
 # Dev

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,0 +1,4 @@
+[tools]
+rojo = { source = "rojo-rbx/rojo", version = "=7.2.1" }
+selene = { source = "Kampfkarren/selene", version = "0.20.0" }
+wally = { source = "UpliftGames/wally", version = "0.3.1" }

--- a/hotswap.project.json
+++ b/hotswap.project.json
@@ -1,0 +1,18 @@
+{
+	"name": "StudioComponentsHotswap",
+	"tree": {
+		"$className": "DataModel",
+		"ReplicatedStorage": {
+			"$className": "ReplicatedStorage",
+			"Plugin" : {
+				"$path": "plugin",
+				"Packages": {
+					"$path": "Packages",
+					"StudioComponents": {
+						"$path": "src"
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Dropdown.story.lua
+++ b/src/Dropdown.story.lua
@@ -6,7 +6,7 @@ local Dropdown = require(script.Parent.Dropdown)
 local Wrapper = Roact.Component:extend("Wrapper")
 
 local items = string.split(
-	"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+	"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua llllllllloooooooonnnnnnggggggggg",
 	" "
 )
 
@@ -18,6 +18,9 @@ function Wrapper:render()
 	return Roact.createElement(Dropdown, {
 		Items = items,
 		Item = self.state.Item,
+		Width = UDim.new(0, 100),
+		Position = UDim2.fromScale(0.5, 0.5),
+		AnchorPoint = Vector2.new(0.5, 0.5),
 		OnSelected = function(item)
 			self:setState({ Item = item })
 		end,

--- a/src/Dropdown/Constants.lua
+++ b/src/Dropdown/Constants.lua
@@ -1,7 +1,0 @@
-return {
-	RowHeightTop = 20,
-	RowHeightItem = 15,
-	TextPaddingLeft = 5,
-	TextPaddingRight = 3,
-	MaxVisibleRows = 6,
-}

--- a/src/Dropdown/DropdownItem.lua
+++ b/src/Dropdown/DropdownItem.lua
@@ -1,7 +1,6 @@
 local Packages = script.Parent.Parent.Parent
 local Roact = require(Packages.Roact)
 
-local DropdownConstants = require(script.Parent.Constants)
 local Constants = require(script.Parent.Parent.Constants)
 local withTheme = require(script.Parent.Parent.withTheme)
 
@@ -31,7 +30,7 @@ function DropdownItem:render()
 		return Roact.createElement("TextButton", {
 			AutoButtonColor = false,
 			LayoutOrder = self.props.LayoutOrder,
-			Size = UDim2.new(1, 0, 0, DropdownConstants.RowHeightItem),
+			Size = UDim2.new(1, 0, 0, self.props.RowHeightItem),
 			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.EmulatorBar, modifier),
 			BorderSizePixel = 0,
 			Text = self.props.Item,
@@ -47,8 +46,8 @@ function DropdownItem:render()
 			end,
 		}, {
 			Padding = Roact.createElement("UIPadding", {
-				PaddingLeft = UDim.new(0, DropdownConstants.TextPaddingLeft - 1),
-				PaddingRight = UDim.new(0, DropdownConstants.TextPaddingRight),
+				PaddingLeft = UDim.new(0, self.props.TextPaddingLeft),
+				PaddingRight = UDim.new(0, self.props.TextPaddingRight),
 			}),
 		})
 	end)

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -1,14 +1,24 @@
 local Packages = script.Parent.Parent
 local Roact = require(Packages.Roact)
 
-local DropdownConstants = require(script.Constants)
 local Constants = require(script.Parent.Constants)
 local withTheme = require(script.Parent.withTheme)
+local joinDictionaries = require(script.Parent.joinDictionaries)
+
+local dropdownConstants = {
+	TextPaddingLeft = 5,
+	TextPaddingRight = 3,
+}
+
+local dropdownDefaults = {
+	RowHeightTop = 20,
+	RowHeightItem = 15,
+	MaxVisibleRows = 6,
+}
 
 --[[
 todo:
 - props.Disabled
-- props for position/anchor/size
 - should it have a border?
 - close when clicked outside (preferably compatible with AutomaticSize - no big frame)
 - consider lifting open/closed state up (compatibility with mutually exclusive dropdowns)
@@ -56,27 +66,39 @@ function Dropdown:render()
 	end
 
 	return withTheme(function(theme)
+		local dropdownOptions = joinDictionaries(dropdownDefaults, {
+			Width = self.props.Width,
+			RowHeightTop = self.props.RowHeightTop,
+			RowHeightItem = self.props.RowHeightItem,
+			MaxVisibleRows = self.props.MaxVisibleRows,
+		})
+
 		local items = {}
 		if self.state.Open then
 			for i, item in ipairs(self.props.Items) do
 				items[i] = Roact.createElement(DropdownItem, {
 					Item = item,
 					LayoutOrder = i,
+					RowHeightItem = dropdownOptions.RowHeightItem,
+					TextPaddingLeft = dropdownConstants.TextPaddingLeft - 1,
+					TextPaddingRight = dropdownConstants.TextPaddingRight,
 					OnSelected = self.onSelectedItem,
 				})
 			end
 		end
 
 		local rowPadding = 1
-		local visibleItems = math.min(DropdownConstants.MaxVisibleRows, #items)
-		local scrollHeight = visibleItems * DropdownConstants.RowHeightItem -- item heights
+		local visibleItems = math.min(dropdownOptions.MaxVisibleRows, #items)
+		local scrollHeight = visibleItems * dropdownOptions.RowHeightItem -- item heights
 			+ (visibleItems - 1) * rowPadding -- row padding
 			+ 2 -- top and bottom borders
 
+		print(dropdownOptions.Width)
+
 		return Roact.createElement("Frame", {
-			Size = UDim2.fromOffset(100, DropdownConstants.RowHeightTop), -- prop (width - UDim?)
-			Position = UDim2.fromScale(0.5, 0.5), -- prop
-			AnchorPoint = Vector2.new(0.5, 0.5), -- prop
+			Size = UDim2.new(dropdownOptions.Width.Scale, dropdownOptions.Width.Offset, 0, dropdownOptions.RowHeightTop),
+			Position = self.props.Position,
+			AnchorPoint = self.props.AnchorPoint,
 			BackgroundTransparency = 1,
 			[Roact.Event.InputBegan] = self.onSelectedInputBegan,
 			[Roact.Event.InputEnded] = self.onSelectedInputEnded,
@@ -92,10 +114,11 @@ function Dropdown:render()
 				TextSize = Constants.TextSize,
 				TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
 				TextXAlignment = Enum.TextXAlignment.Left,
+				TextTruncate = Enum.TextTruncate.AtEnd,
 			}, {
 				Padding = Roact.createElement("UIPadding", {
-					PaddingLeft = UDim.new(0, DropdownConstants.TextPaddingLeft),
-					PaddingRight = UDim.new(0, DropdownConstants.TextPaddingRight),
+					PaddingLeft = UDim.new(0, dropdownConstants.TextPaddingLeft),
+					PaddingRight = UDim.new(0, dropdownConstants.TextPaddingRight),
 				}),
 			}),
 			ArrowContainer = Roact.createElement("Frame", {

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -93,8 +93,6 @@ function Dropdown:render()
 			+ (visibleItems - 1) * rowPadding -- row padding
 			+ 2 -- top and bottom borders
 
-		print(dropdownOptions.Width)
-
 		return Roact.createElement("Frame", {
 			Size = UDim2.new(dropdownOptions.Width.Scale, dropdownOptions.Width.Offset, 0, dropdownOptions.RowHeightTop),
 			Position = self.props.Position,


### PR DESCRIPTION
This PR does the following to the dropdown component:
- Adds `Position` and `AnchorPoint` properties
- Adds a new `Width` UDim property instead of locking it to a constant
- Changes `RowHeightTop`, `RowHeightItem`, `MaxVisibleRows` from being constants to instead be able to be set by the dev and uses the previous constant values as defaults