### PR TITLE
Update theme

### DIFF
--- a/src/ThemeContext.lua
+++ b/src/ThemeContext.lua
@@ -1,0 +1,4 @@
+local Packages = script.Parent.Parent
+local Roact = require(Packages.Roact)
+
+return Roact.createContext()

--- a/src/init.lua
+++ b/src/init.lua
@@ -12,5 +12,6 @@ return {
 	VerticalCollapsibleSection = require(script.VerticalCollapsibleSection),
 	VerticalExpandingList = require(script.VerticalExpandingList),
 	Widget = require(script.Widget),
+	ThemeContext = require(script.ThemeContext),
 	withTheme = require(script.withTheme),
 }

--- a/src/withTheme.lua
+++ b/src/withTheme.lua
@@ -9,31 +9,13 @@ function StudioThemeProvider:init()
 	local theme = self:GetContext(ThemeContext)
 	self:setState({ studioTheme = studioSettings.Theme })
 
-	if theme == nil then
-		self._changed = studioSettings.ThemeChanged:Connect(function()
-			self:setState({ studioTheme = studioSettings.Theme })
-		end)
-	end
+	self._changed = studioSettings.ThemeChanged:Connect(function()
+		self:setState({ studioTheme = studioSettings.Theme })
+	end)
 end
 
 function StudioThemeProvider:willUnmount()
-	if self._changed then
-		self._changed:Disconnect()
-	end
-end
-
-function StudioThemeProvider:willUpdate()
-	local theme = self:GetContext(ThemeContext)
-	if theme and self._changed then
-		self._changed:Disconnect()
-		self._changed = nil
-	elseif theme == nil then
-		self._changed = studioSettings.ThemeChanged:Connect(function()
-			self:setState({ studioTheme = studioSettings.Theme })
-		end)
-
-		task.defer(self.setState, self, { studioTheme = studioSettings.Theme })
-	end
+	self._changed:Disconnect()
 end
 
 function StudioThemeProvider:render()

--- a/src/withTheme.lua
+++ b/src/withTheme.lua
@@ -18,44 +18,28 @@ function StudioThemeProvider:willUnmount()
 end
 
 function StudioThemeProvider:render()
-	local theme = self:GetContext(ThemeContext)
 	local render = Roact.oneChild(self.props[Roact.Children])
 
-	if theme then
-		return render(theme)
-	else
-		return Roact.createElement(ThemeContext.Provider, {
-			value = self.state.studioTheme,
-		}, {
-			Consumer = Roact.createElement(ThemeContext.Consumer, {
-				render = render,
-			}),
-		})
-	end
-end
-
--- https://github.com/Kampfkarren/roact-hooks/blob/main/src/createUseContext.lua
-function StudioThemeProvider:GetContext(targetContext)
-	local contextValue
-
-	local fakeConsumer = setmetatable({
-		props = {
-			render = function(value)
-				contextValue = value
-			end,
-		},
+	return Roact.createElement(ThemeContext.Provider, {
+		value = self.state.studioTheme,
 	}, {
-		__index = self,
+		Consumer = Roact.createElement(ThemeContext.Consumer, {
+			render = render,
+		})
 	})
-
-	targetContext.Consumer.init(fakeConsumer)
-
-	return contextValue
 end
 
 local function withTheme(render)
-	return Roact.createElement(StudioThemeProvider, {}, {
-		render = render,
+	return Roact.createElement(ThemeContext.Consumer, {
+		render = function(theme)
+			if theme then
+				return render(theme)
+			else
+				return Roact.createElement(StudioThemeProvider, {}, {
+					render = render,
+				})
+			end
+		end
 	})
 end
 

--- a/src/withTheme.lua
+++ b/src/withTheme.lua
@@ -1,23 +1,75 @@
 local Packages = script.Parent.Parent
 local Roact = require(Packages.Roact)
+local ThemeContext = require(script.Parent.ThemeContext)
 
 local StudioThemeProvider = Roact.Component:extend("StudioThemeProvider")
 local studioSettings = settings().Studio
 
 function StudioThemeProvider:init()
-	self:setState({ theme = studioSettings.Theme })
-	self._changed = studioSettings.ThemeChanged:Connect(function()
-		self:setState({ theme = studioSettings.Theme })
-	end)
+	local theme = self:GetContext(ThemeContext)
+	self:setState({ studioTheme = studioSettings.Theme })
+
+	if theme == nil then
+		self._changed = studioSettings.ThemeChanged:Connect(function()
+			self:setState({ studioTheme = studioSettings.Theme })
+		end)
+	end
 end
 
 function StudioThemeProvider:willUnmount()
-	self._changed:Disconnect()
+	if self._changed then
+		self._changed:Disconnect()
+	end
+end
+
+function StudioThemeProvider:willUpdate()
+	local theme = self:GetContext(ThemeContext)
+	if theme and self._changed then
+		self._changed:Disconnect()
+		self._changed = nil
+	elseif theme == nil then
+		self._changed = studioSettings.ThemeChanged:Connect(function()
+			self:setState({ studioTheme = studioSettings.Theme })
+		end)
+
+		task.defer(self.setState, self, { studioTheme = studioSettings.Theme })
+	end
 end
 
 function StudioThemeProvider:render()
+	local theme = self:GetContext(ThemeContext)
 	local render = Roact.oneChild(self.props[Roact.Children])
-	return render(self.state.theme)
+
+	if theme then
+		return render(theme)
+	else
+		return Roact.createElement(ThemeContext.Provider, {
+			value = self.state.studioTheme,
+		}, {
+			Consumer = Roact.createElement(ThemeContext.Consumer, {
+				render = render,
+			}),
+		})
+	end
+end
+
+-- https://github.com/Kampfkarren/roact-hooks/blob/main/src/createUseContext.lua
+function StudioThemeProvider:GetContext(targetContext)
+	local contextValue = nil
+
+	local fakeConsumer = setmetatable({
+		props = {
+			render = function(value)
+				contextValue = value
+			end,
+		},
+	}, {
+		__index = self,
+	})
+
+	targetContext.Consumer.init(fakeConsumer)
+
+	return contextValue
 end
 
 local function withTheme(render)

--- a/src/withTheme.lua
+++ b/src/withTheme.lua
@@ -6,7 +6,6 @@ local StudioThemeProvider = Roact.Component:extend("StudioThemeProvider")
 local studioSettings = settings().Studio
 
 function StudioThemeProvider:init()
-	local theme = self:GetContext(ThemeContext)
 	self:setState({ studioTheme = studioSettings.Theme })
 
 	self._changed = studioSettings.ThemeChanged:Connect(function()
@@ -37,7 +36,7 @@ end
 
 -- https://github.com/Kampfkarren/roact-hooks/blob/main/src/createUseContext.lua
 function StudioThemeProvider:GetContext(targetContext)
-	local contextValue = nil
+	local contextValue
 
 	local fakeConsumer = setmetatable({
 		props = {


### PR DESCRIPTION
Partially address #14.

Changes:
- There is a new ThemeContext that is publicly exposed. Library consumers can now force a theme using `ThemContext.Provider`, passing a theme object.
- `useTheme.lua` now uses the new ThemeContext instead. There are no breaking changes. 

Consideration:
- Earlier I experimented with automatically disconnecting from ThemeChanged as an optimization. However, I felt it was too complex for whatever gain was there. Is it worth adding?