### PR TITLE
Match withTheme behavior 1-1

### DIFF
--- a/src/useTheme.lua
+++ b/src/useTheme.lua
@@ -6,6 +6,7 @@ local function useTheme(hooks)
 	local studioTheme, setStudioTheme = hooks.useState(studio.Theme)
 
 	hooks.useEffect(function()
+		if theme then return end
 		local connection = studio.ThemeChanged:Connect(function()
 			setStudioTheme(studio.Theme)
 		end)


### PR DESCRIPTION
withTheme does not make a connection if possible.
This patch ensures that in the useEffect, a connection isn't made if not needed.