### PR TITLE
Dropdown improvements

### DIFF
--- a/src/Dropdown.story.lua
+++ b/src/Dropdown.story.lua
@@ -11,16 +11,62 @@ local items = string.split(
 )
 
 function Wrapper:init()
-	self:setState({ Item = "Lorem" })
+	self:setState({
+		ShowLastRow = true,
+		Item0 = "Lorem",
+		Item1 = "dolor",
+		Item2 = "sit",
+		Item3 = "amet",
+	})
 end
 
 function Wrapper:render()
-	return Roact.createElement(Dropdown, {
-		Items = items,
-		Item = self.state.Item,
-		OnSelected = function(item)
-			self:setState({ Item = item })
-		end,
+	return Roact.createFragment({
+		Layout = Roact.createElement("UIGridLayout", {
+			CellPadding = UDim2.new(0, 10, 0, 10),
+			CellSize = UDim2.new(0.3, 0, 0, 20),
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			FillDirection = Enum.FillDirection.Horizontal,
+			VerticalAlignment = Enum.VerticalAlignment.Center,
+			HorizontalAlignment = Enum.HorizontalAlignment.Center,
+			FillDirectionMaxCells = 2,
+		}),
+
+		Dropdown0 = Roact.createElement(Dropdown, {
+			LayoutOrder = 0,
+			Items = table.clone(items),
+			Item = self.state.Item0,
+			OnSelected = function(item)
+				self:setState({ Item0 = item })
+			end,
+		}),
+
+		Dropdown1 = Roact.createElement(Dropdown, {
+			LayoutOrder = 1,
+			Items = table.clone(items),
+			Item = self.state.Item1,
+			OnSelected = function(item)
+				self:setState({ Item1 = item })
+			end,
+		}),
+
+		Dropdown2 = Roact.createElement(Dropdown, {
+			LayoutOrder = 2,
+			Items = table.clone(items),
+			Item = self.state.Item2,
+			OnSelected = function(item)
+				self:setState({ Item2 = item })
+			end,
+		}),
+
+		Dropdown3 = Roact.createElement(Dropdown, {
+			LayoutOrder = 3,
+			Items = table.clone(items),
+			Item = self.state.Item3,
+			OnSelected = function(item)
+				self:setState({ Item3 = item })
+			end,
+		}),
 	})
 end
 

--- a/src/Dropdown.story.lua
+++ b/src/Dropdown.story.lua
@@ -35,8 +35,8 @@ function Wrapper:render()
 		Dropdown0 = Roact.createElement(Dropdown, {
 			LayoutOrder = 0,
 			Items = table.clone(words),
-			Item = self.state.Item0,
-			OnSelected = function(item)
+			SelectedItem = self.state.Item0,
+			OnItemSelected = function(item)
 				self:setState({ Item0 = item })
 			end,
 		}),
@@ -44,8 +44,8 @@ function Wrapper:render()
 		Dropdown1 = Roact.createElement(Dropdown, {
 			LayoutOrder = 1,
 			Items = table.clone(words),
-			Item = self.state.Item1,
-			OnSelected = function(item)
+			SelectedItem = self.state.Item1,
+			OnItemSelected = function(item)
 				self:setState({ Item1 = item })
 			end,
 		}),
@@ -53,8 +53,8 @@ function Wrapper:render()
 		Dropdown2 = Roact.createElement(Dropdown, {
 			LayoutOrder = 2,
 			Items = table.clone(words),
-			Item = self.state.Item2,
-			OnSelected = function(item)
+			SelectedItem = self.state.Item2,
+			OnItemSelected = function(item)
 				self:setState({ Item2 = item })
 			end,
 		}),
@@ -62,8 +62,8 @@ function Wrapper:render()
 		Dropdown3 = Roact.createElement(Dropdown, {
 			LayoutOrder = 3,
 			Items = table.clone(words),
-			Item = self.state.Item3,
-			OnSelected = function(item)
+			SelectedItem = self.state.Item3,
+			OnItemSelected = function(item)
 				self:setState({ Item3 = item })
 			end,
 			Disabled = true,

--- a/src/Dropdown.story.lua
+++ b/src/Dropdown.story.lua
@@ -2,17 +2,19 @@ local Packages = script.Parent.Parent
 local Roact = require(Packages.Roact)
 
 local Dropdown = require(script.Parent.Dropdown)
+--local ScrollFrame = require(script.Parent.ScrollFrame)
 
-local Wrapper = Roact.Component:extend("Wrapper")
-
-local items = string.split(
+local words = string.split(
 	"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
 	" "
 )
+table.insert(words, "Long final test dropdown option")
 
+local Wrapper = Roact.Component:extend("Wrapper")
+
+--[[
 function Wrapper:init()
 	self:setState({
-		ShowLastRow = true,
 		Item0 = "Lorem",
 		Item1 = "dolor",
 		Item2 = "sit",
@@ -34,7 +36,7 @@ function Wrapper:render()
 
 		Dropdown0 = Roact.createElement(Dropdown, {
 			LayoutOrder = 0,
-			Items = table.clone(items),
+			Items = table.clone(words),
 			Item = self.state.Item0,
 			OnSelected = function(item)
 				self:setState({ Item0 = item })
@@ -43,7 +45,7 @@ function Wrapper:render()
 
 		Dropdown1 = Roact.createElement(Dropdown, {
 			LayoutOrder = 1,
-			Items = table.clone(items),
+			Items = table.clone(words),
 			Item = self.state.Item1,
 			OnSelected = function(item)
 				self:setState({ Item1 = item })
@@ -52,7 +54,7 @@ function Wrapper:render()
 
 		Dropdown2 = Roact.createElement(Dropdown, {
 			LayoutOrder = 2,
-			Items = table.clone(items),
+			Items = table.clone(words),
 			Item = self.state.Item2,
 			OnSelected = function(item)
 				self:setState({ Item2 = item })
@@ -61,12 +63,62 @@ function Wrapper:render()
 
 		Dropdown3 = Roact.createElement(Dropdown, {
 			LayoutOrder = 3,
-			Items = table.clone(items),
+			Items = table.clone(words),
 			Item = self.state.Item3,
 			OnSelected = function(item)
 				self:setState({ Item3 = item })
 			end,
 		}),
+	})
+end
+--]]
+
+--[[
+local count = 20
+
+function Wrapper:init()
+	self:setState(table.create(count, words[1]))
+end
+
+function Wrapper:render()
+	local items = table.create(count)
+	for i = 1, count do
+		items[i] = Roact.createElement(Dropdown, {
+			LayoutOrder = i,
+			Items = table.clone(words),
+			Item = self.state[i],
+			OnSelected = function(item)
+				self:setState({ [i] = item })
+			end,
+		})
+	end
+
+	return Roact.createElement(ScrollFrame, {
+		AnchorPoint = Vector2.new(0.5, 0.5),
+		Position = UDim2.fromScale(0.5, 0.5),
+		Size = UDim2.new(1, -200, 1, -200),
+		Layout = {
+			Padding = UDim.new(0, 5),
+		},
+	}, items)
+end
+]]
+
+function Wrapper:init()
+	self:setState({ Item = "Lorem" })
+end
+
+function Wrapper:render()
+	return Roact.createElement(Dropdown, {
+		AnchorPoint = Vector2.new(0.5, 0.5),
+		Position = UDim2.fromScale(0.5, 0.5),
+		Width = UDim.new(0, 200),
+		Items = table.clone(words),
+		Item = self.state.Item,
+		MaxVisibleRows = 5,
+		OnSelected = function(item)
+			self:setState({ Item = item })
+		end,
 	})
 end
 

--- a/src/Dropdown.story.lua
+++ b/src/Dropdown.story.lua
@@ -2,7 +2,6 @@ local Packages = script.Parent.Parent
 local Roact = require(Packages.Roact)
 
 local Dropdown = require(script.Parent.Dropdown)
---local ScrollFrame = require(script.Parent.ScrollFrame)
 
 local words = string.split(
 	"Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
@@ -12,7 +11,6 @@ table.insert(words, "Long final test dropdown option")
 
 local Wrapper = Roact.Component:extend("Wrapper")
 
---[[
 function Wrapper:init()
 	self:setState({
 		Item0 = "Lorem",
@@ -68,57 +66,8 @@ function Wrapper:render()
 			OnSelected = function(item)
 				self:setState({ Item3 = item })
 			end,
+			Disabled = true,
 		}),
-	})
-end
---]]
-
---[[
-local count = 20
-
-function Wrapper:init()
-	self:setState(table.create(count, words[1]))
-end
-
-function Wrapper:render()
-	local items = table.create(count)
-	for i = 1, count do
-		items[i] = Roact.createElement(Dropdown, {
-			LayoutOrder = i,
-			Items = table.clone(words),
-			Item = self.state[i],
-			OnSelected = function(item)
-				self:setState({ [i] = item })
-			end,
-		})
-	end
-
-	return Roact.createElement(ScrollFrame, {
-		AnchorPoint = Vector2.new(0.5, 0.5),
-		Position = UDim2.fromScale(0.5, 0.5),
-		Size = UDim2.new(1, -200, 1, -200),
-		Layout = {
-			Padding = UDim.new(0, 5),
-		},
-	}, items)
-end
-]]
-
-function Wrapper:init()
-	self:setState({ Item = "Lorem" })
-end
-
-function Wrapper:render()
-	return Roact.createElement(Dropdown, {
-		AnchorPoint = Vector2.new(0.5, 0.5),
-		Position = UDim2.fromScale(0.5, 0.5),
-		Width = UDim.new(0, 200),
-		Items = table.clone(words),
-		Item = self.state.Item,
-		MaxVisibleRows = 5,
-		OnSelected = function(item)
-			self:setState({ Item = item })
-		end,
 	})
 end
 

--- a/src/Dropdown/Constants.lua
+++ b/src/Dropdown/Constants.lua
@@ -1,7 +1,0 @@
-return {
-	RowHeightTop = 20,
-	RowHeightItem = 15,
-	TextPaddingLeft = 5,
-	TextPaddingRight = 3,
-	MaxVisibleRows = 6,
-}

--- a/src/Dropdown/DropdownItem.lua
+++ b/src/Dropdown/DropdownItem.lua
@@ -1,7 +1,6 @@
 local Packages = script.Parent.Parent.Parent
 local Roact = require(Packages.Roact)
 
-local DropdownConstants = require(script.Parent.Constants)
 local Constants = require(script.Parent.Parent.Constants)
 local withTheme = require(script.Parent.Parent.withTheme)
 
@@ -31,7 +30,7 @@ function DropdownItem:render()
 		return Roact.createElement("TextButton", {
 			AutoButtonColor = false,
 			LayoutOrder = self.props.LayoutOrder,
-			Size = UDim2.new(1, 0, 0, DropdownConstants.RowHeightItem),
+			Size = UDim2.new(1, 0, 0, self.props.RowHeightItem),
 			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.EmulatorBar, modifier),
 			BorderSizePixel = 0,
 			Text = self.props.Item,
@@ -47,8 +46,8 @@ function DropdownItem:render()
 			end,
 		}, {
 			Padding = Roact.createElement("UIPadding", {
-				PaddingLeft = UDim.new(0, DropdownConstants.TextPaddingLeft - 1),
-				PaddingRight = UDim.new(0, DropdownConstants.TextPaddingRight),
+				PaddingLeft = UDim.new(0, self.props.TextPaddingLeft - 1),
+				PaddingRight = UDim.new(0, self.props.TextPaddingRight),
 			}),
 		})
 	end)

--- a/src/Dropdown/DropdownItem.lua
+++ b/src/Dropdown/DropdownItem.lua
@@ -1,56 +1,55 @@
 local Packages = script.Parent.Parent.Parent
+
 local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
 
 local Constants = require(script.Parent.Parent.Constants)
-local withTheme = require(script.Parent.Parent.withTheme)
+local useTheme = require(script.Parent.Parent.useTheme)
 
-local DropdownItem = Roact.Component:extend("DropdownItem")
+local function DropdownItem(props, hooks)
+	local theme = useTheme(hooks)
+	local hovered, setHovered = hooks.useState(false)
 
-function DropdownItem:init()
-	self:setState({ Hover = false })
-	self.onInputBegan = function(_rbx, input)
+	local onInputBegan = function(_rbx, input)
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
-			self:setState({ Hover = true })
+			setHovered(true)
 		end
 	end
-	self.onInputEnded = function(_rbx, input)
+
+	local onInputEnded = function(_rbx, input)
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
-			self:setState({ Hover = false })
+			setHovered(false)
 		end
 	end
-end
 
-function DropdownItem:render()
 	local modifier = Enum.StudioStyleGuideModifier.Default
-	if self.state.Hover then
+	if hovered then
 		modifier = Enum.StudioStyleGuideModifier.Hover
 	end
 
-	return withTheme(function(theme)
-		return Roact.createElement("TextButton", {
-			AutoButtonColor = false,
-			LayoutOrder = self.props.LayoutOrder,
-			Size = UDim2.new(1, 0, 0, self.props.RowHeightItem),
-			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.EmulatorBar, modifier),
-			BorderSizePixel = 0,
-			Text = self.props.Item,
-			Font = Constants.Font,
-			TextSize = Constants.TextSize,
-			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
-			TextXAlignment = Enum.TextXAlignment.Left,
-			TextTruncate = Enum.TextTruncate.AtEnd,
-			[Roact.Event.InputBegan] = self.onInputBegan,
-			[Roact.Event.InputEnded] = self.onInputEnded,
-			[Roact.Event.Activated] = function()
-				self.props.OnSelected(self.props.Item)
-			end,
-		}, {
-			Padding = Roact.createElement("UIPadding", {
-				PaddingLeft = UDim.new(0, self.props.TextPaddingLeft - 1),
-				PaddingRight = UDim.new(0, self.props.TextPaddingRight),
-			}),
-		})
-	end)
+	return Roact.createElement("TextButton", {
+		AutoButtonColor = false,
+		LayoutOrder = props.LayoutOrder,
+		Size = UDim2.new(1, 0, 0, props.RowHeightItem),
+		BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.EmulatorBar, modifier),
+		BorderSizePixel = 0,
+		Text = props.Item,
+		Font = Constants.Font,
+		TextSize = Constants.TextSize,
+		TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
+		TextXAlignment = Enum.TextXAlignment.Left,
+		TextTruncate = Enum.TextTruncate.AtEnd,
+		[Roact.Event.InputBegan] = onInputBegan,
+		[Roact.Event.InputEnded] = onInputEnded,
+		[Roact.Event.Activated] = function()
+			props.OnSelected(props.Item)
+		end,
+	}, {
+		Padding = Roact.createElement("UIPadding", {
+			PaddingLeft = UDim.new(0, props.TextPaddingLeft - 1),
+			PaddingRight = UDim.new(0, props.TextPaddingRight),
+		}),
+	})
 end
 
-return DropdownItem
+return Hooks.new(Roact)(DropdownItem)

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -1,9 +1,12 @@
 local Packages = script.Parent.Parent
+
 local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
 
 local DropdownConstants = require(script.Constants)
 local Constants = require(script.Parent.Constants)
-local withTheme = require(script.Parent.withTheme)
+
+local useTheme = require(script.Parent.useTheme)
 
 --[[
 todo:
@@ -18,110 +21,106 @@ todo:
 local ScrollFrame = require(script.Parent.ScrollFrame)
 local DropdownItem = require(script.DropdownItem)
 
-local Dropdown = Roact.Component:extend("Dropdown")
+local function Dropdown(props, hooks)
+	local theme = useTheme(hooks)
+	local open, setOpen = hooks.useState(false)
+	local hovered, setHovered = hooks.useState(false)
 
-function Dropdown:init()
-	self:setState({
-		Open = false,
-		Hover = false,
-	})
-	self.onSelectedInputBegan = function(_rbx, input)
+	local onSelectedInputBegan = function(_rbx, input)
 		local t = input.UserInputType
 		if t == Enum.UserInputType.MouseMovement then
-			self:setState({ Hover = true })
+			setHovered(true)
 		elseif t == Enum.UserInputType.MouseButton1 then
-			self:setState({ Open = not self.state.Open })
+			setOpen(not open) -- what if disabled?
 		end
 	end
-	self.onSelectedInputEnded = function(_rbx, input)
-		if input.UserInputType == Enum.UserInputType.MouseMovement then
-			self:setState({ Hover = false })
-		end
-	end
-	self.onSelectedItem = function(item)
-		self:setState({ Open = false })
-		self.props.OnSelected(item)
-	end
-end
 
-function Dropdown:render()
+	local onSelectedInputEnded = function(_rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			setHovered(false)
+		end
+	end
+
+	local onSelectedItem = function(item)
+		setOpen(false)
+		props.OnSelected(item)
+	end
+
 	local modifier = Enum.StudioStyleGuideModifier.Default
-	if self.state.Hover then
+	if hovered then
 		modifier = Enum.StudioStyleGuideModifier.Hover
 	end
 
 	local background = Enum.StudioStyleGuideColor.MainBackground
-	if self.state.Open or self.state.Hover then
+	if open or hovered then
 		background = Enum.StudioStyleGuideColor.InputFieldBackground
 	end
 
-	return withTheme(function(theme)
-		local items = {}
-		if self.state.Open then
-			for i, item in ipairs(self.props.Items) do
-				items[i] = Roact.createElement(DropdownItem, {
-					Item = item,
-					LayoutOrder = i,
-					OnSelected = self.onSelectedItem,
-				})
-			end
+	local items = {}
+	if open then
+		for i, item in ipairs(props.Items) do
+			items[i] = Roact.createElement(DropdownItem, {
+				Item = item,
+				LayoutOrder = i,
+				OnSelected = onSelectedItem,
+			})
 		end
+	end
 
-		local rowPadding = 1
-		local visibleItems = math.min(DropdownConstants.MaxVisibleRows, #items)
-		local scrollHeight = visibleItems * DropdownConstants.RowHeightItem -- item heights
-			+ (visibleItems - 1) * rowPadding -- row padding
-			+ 2 -- top and bottom borders
+	local rowPadding = 1
+	local visibleItems = math.min(DropdownConstants.MaxVisibleRows, #items)
+	local scrollHeight = visibleItems * DropdownConstants.RowHeightItem -- item heights
+		+ (visibleItems - 1) * rowPadding -- row padding
+		+ 2 -- top and bottom borders
 
-		return Roact.createElement("Frame", {
-			Size = UDim2.fromOffset(100, DropdownConstants.RowHeightTop), -- prop (width - UDim?)
-			Position = UDim2.fromScale(0.5, 0.5), -- prop
-			AnchorPoint = Vector2.new(0.5, 0.5), -- prop
-			BackgroundTransparency = 1,
-			[Roact.Event.InputBegan] = self.onSelectedInputBegan,
-			[Roact.Event.InputEnded] = self.onSelectedInputEnded,
+	return Roact.createElement("Frame", {
+		Size = UDim2.fromOffset(100, DropdownConstants.RowHeightTop), -- prop (width - UDim?)
+		Position = UDim2.fromScale(0.5, 0.5), -- prop
+		AnchorPoint = Vector2.new(0.5, 0.5), -- prop
+		BackgroundTransparency = 1,
+		[Roact.Event.InputBegan] = onSelectedInputBegan,
+		[Roact.Event.InputEnded] = onSelectedInputEnded,
+	}, {
+		Selected = Roact.createElement("TextLabel", {
+			Size = UDim2.fromScale(1, 1),
+			BackgroundColor3 = theme:GetColor(background, modifier),
+			BorderMode = Enum.BorderMode.Inset,
+			BorderSizePixel = 1,
+			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border, modifier),
+			Text = props.Item,
+			Font = Constants.Font,
+			TextSize = Constants.TextSize,
+			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
+			TextXAlignment = Enum.TextXAlignment.Left,
 		}, {
-			Selected = Roact.createElement("TextLabel", {
-				Size = UDim2.fromScale(1, 1),
-				BackgroundColor3 = theme:GetColor(background, modifier),
-				BorderMode = Enum.BorderMode.Inset,
-				BorderSizePixel = 1,
-				BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border, modifier),
-				Text = self.props.Item,
-				Font = Constants.Font,
-				TextSize = Constants.TextSize,
-				TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
-				TextXAlignment = Enum.TextXAlignment.Left,
-			}, {
-				Padding = Roact.createElement("UIPadding", {
-					PaddingLeft = UDim.new(0, DropdownConstants.TextPaddingLeft),
-					PaddingRight = UDim.new(0, DropdownConstants.TextPaddingRight),
-				}),
+			Padding = Roact.createElement("UIPadding", {
+				PaddingLeft = UDim.new(0, DropdownConstants.TextPaddingLeft),
+				PaddingRight = UDim.new(0, DropdownConstants.TextPaddingRight),
 			}),
-			ArrowContainer = Roact.createElement("Frame", {
-				AnchorPoint = Vector2.new(1, 0),
-				Position = UDim2.fromScale(1, 0),
-				Size = UDim2.new(0, 18, 1, 0),
+		}),
+		ArrowContainer = Roact.createElement("Frame", {
+			AnchorPoint = Vector2.new(1, 0),
+			Position = UDim2.fromScale(1, 0),
+			Size = UDim2.new(0, 18, 1, 0),
+			BackgroundTransparency = 1,
+		}, {
+			Arrow = Roact.createElement("ImageLabel", {
+				Image = "rbxassetid://7260137654",
+				AnchorPoint = Vector2.new(0.5, 0.5),
+				Position = UDim2.fromScale(0.5, 0.5),
+				Size = UDim2.fromOffset(8, 4),
 				BackgroundTransparency = 1,
-			}, {
-				Arrow = Roact.createElement("ImageLabel", {
-					Image = "rbxassetid://7260137654",
-					AnchorPoint = Vector2.new(0.5, 0.5),
-					Position = UDim2.fromScale(0.5, 0.5),
-					Size = UDim2.fromOffset(8, 4),
-					BackgroundTransparency = 1,
-					ImageColor3 = theme:GetColor(Enum.StudioStyleGuideColor.TitlebarText, modifier),
-				}),
+				ImageColor3 = theme:GetColor(Enum.StudioStyleGuideColor.TitlebarText, modifier),
 			}),
-			Drop = self.state.Open and Roact.createElement(ScrollFrame, {
-				Position = UDim2.new(0, 0, 1, -1),
-				Size = UDim2.new(1, 0, 0, scrollHeight),
-				Layout = {
-					Padding = UDim.new(0, rowPadding),
-				},
-			}, items),
-		})
-	end)
+		}),
+		Drop = open and Roact.createElement(ScrollFrame, {
+			Position = UDim2.new(0, 0, 1, -1),
+			Size = UDim2.new(1, 0, 0, scrollHeight),
+			Layout = {
+				Padding = UDim.new(0, rowPadding),
+			},
+		}, items),
+	})
 end
 
-return Dropdown
+return Hooks.new(Roact)(Dropdown)

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -111,7 +111,25 @@ local function Dropdown(props, hooks)
 	if not props.Disabled and open and rootRef.value then
 		local inst = rootRef.value:getValue()
 		local target = inst:FindFirstAncestorWhichIsA("LayerCollector")
+
 		if target ~= nil then
+			local pos = inst.AbsolutePosition
+			local size = inst.AbsoluteSize
+
+			local spaceBelow = target.AbsoluteSize.y - size.y - pos.y
+			local spaceAbove = pos.y
+
+			-- render dropdown going upward if both are true:
+			-- 1. not enough space below AND
+			-- 2. more space above
+			local anchor = Vector2.new(0, 0)
+			local posy = math.ceil(pos.y) - 1 + props.RowHeightTop
+			local buffer = 3 -- extra space required below
+			if spaceBelow < scrollHeight + buffer and spaceAbove > spaceBelow then
+				anchor = Vector2.new(0, 1)
+				posy -= props.RowHeightTop
+			end
+
 			catcher = Roact.createElement(Roact.Portal, {
 				target = target,
 			}, {
@@ -122,13 +140,10 @@ local function Dropdown(props, hooks)
 					[Roact.Event.InputBegan] = onCatcherInputBegan,
 				}, {
 					-- rounding etc. here corrects for sub-pixel alignments
-					-- TODO: open upward, instead of down, if insufficient space?
 					Drop = open and Roact.createElement(ScrollFrame, {
-						Position = UDim2.fromOffset(
-							math.round(inst.AbsolutePosition.x) - 1,
-							math.ceil(inst.AbsolutePosition.y) - 1 + props.RowHeightTop
-						),
-						Size = UDim2.fromOffset(math.round(inst.AbsoluteSize.x) + 2, scrollHeight),
+						AnchorPoint = anchor,
+						Position = UDim2.fromOffset(math.round(pos.x) - 1, posy),
+						Size = UDim2.fromOffset(math.round(size.x) + 2, scrollHeight),
 						Layout = {
 							Padding = UDim.new(0, rowPadding),
 						},

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -55,7 +55,7 @@ local function Dropdown(props, hooks)
 	local onSelectedItem = function(item)
 		if not props.Disabled then
 			setOpen(false)
-			props.OnSelected(item)
+			props.OnItemSelected(item)
 		end
 	end
 
@@ -175,7 +175,7 @@ local function Dropdown(props, hooks)
 			Size = UDim2.fromScale(1, 1),
 			BackgroundColor3 = theme:GetColor(background, modifier),
 			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border, modifier),
-			Text = props.Item,
+			Text = props.SelectedItem,
 			Font = Constants.Font,
 			TextSize = Constants.TextSize,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -6,11 +6,6 @@ local Hooks = require(Packages.RoactHooks)
 local Constants = require(script.Parent.Constants)
 local useTheme = require(script.Parent.useTheme)
 
---[[
-todo:
-- props.Disabled + becoming Disabled while open
-]]
-
 local ScrollFrame = require(script.Parent.ScrollFrame)
 local DropdownItem = require(script.DropdownItem)
 
@@ -41,9 +36,13 @@ local function Dropdown(props, hooks)
 	local onSelectedInputBegan = function(_, input)
 		local t = input.UserInputType
 		if t == Enum.UserInputType.MouseMovement then
-			setHovered(true)
+			if not props.Disabled then
+				setHovered(true)
+			end
 		elseif t == Enum.UserInputType.MouseButton1 then
-			setOpen(not open) -- what if disabled?
+			if not props.Disabled then
+				setOpen(not open)
+			end
 		end
 	end
 
@@ -54,12 +53,16 @@ local function Dropdown(props, hooks)
 	end
 
 	local onSelectedItem = function(item)
-		setOpen(false)
-		props.OnSelected(item)
+		if not props.Disabled then
+			setOpen(false)
+			props.OnSelected(item)
+		end
 	end
 
 	local modifier = Enum.StudioStyleGuideModifier.Default
-	if hovered then
+	if props.Disabled then
+		modifier = Enum.StudioStyleGuideModifier.Disabled
+	elseif hovered then
 		modifier = Enum.StudioStyleGuideModifier.Hover
 	end
 
@@ -69,7 +72,7 @@ local function Dropdown(props, hooks)
 	end
 
 	local items = {}
-	if open then
+	if open and not props.Disabled then
 		for i, item in ipairs(props.Items) do
 			items[i] = Roact.createElement(DropdownItem, {
 				Item = item,
@@ -105,7 +108,7 @@ local function Dropdown(props, hooks)
 		end
 	end
 
-	if open and rootRef.value then
+	if not props.Disabled and open and rootRef.value then
 		local inst = rootRef.value:getValue()
 		local target = inst:FindFirstAncestorWhichIsA("LayerCollector")
 		if target ~= nil then

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -180,11 +180,12 @@ local function Dropdown(props, hooks)
 			TextSize = Constants.TextSize,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, modifier),
 			TextXAlignment = Enum.TextXAlignment.Left,
+			TextTruncate = Enum.TextTruncate.AtEnd,
 			ZIndex = 1,
 		}, {
 			Padding = Roact.createElement("UIPadding", {
 				PaddingLeft = UDim.new(0, TEXT_PADDING_LEFT),
-				PaddingRight = UDim.new(0, TEXT_PADDING_RIGHT),
+				PaddingRight = UDim.new(0, 12),
 				PaddingBottom = UDim.new(0, 1),
 			}),
 		}),

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -97,9 +97,9 @@ local function Dropdown(props, hooks)
 		if catchInputs[t] then
 			local inst = rootRef.value:getValue()
 			local off = Vector2.new(input.Position.x, input.Position.y) - inst.AbsolutePosition
-			local max = inst.AbsoluteSize + Vector2.new(0, scrollHeight)
+			local max = inst.AbsoluteSize
 			if off.x < 0 or off.x > max.x or off.y < 0 or off.y > max.y then
-				setOpen(false) -- only run if not clicking over the dropdown/options
+				setOpen(false) -- only run if not clicking over the dropdown top part
 			end
 		elseif t == Enum.UserInputType.Keyboard then
 			if input.KeyCode == Enum.KeyCode.Escape then


### PR DESCRIPTION
This PR improves the Dropdown component in the following ways:
1. Adapted to use hooks
2. Added props for Width, Position, AnchorPoint, MaxVisibleRows, RowHeightTop, and RowHeightItem (derived from 0c96f67e545e88390dd2c1dd268dc5b2c8b56cb8)
3. Click anywhere outside an open Dropdown to close it
4. Press escape to close an open Dropdown (this even works in a Widget as long as it has focus)
5. An open Dropdown's options render above all other items under the same LayerCollector
6. Dropdown goes upwards instead of down if both are satisfied: (1) not enough space below; AND (2) more space above than below
7. Added prop for Disabled
8. Fixed up some text alignment, padding, and truncation

Notes: improvements (3) and (5) require use of a ref and searching the instance hierarchy for a root LayerCollector to act as a portal target. Since we are directly parenting the options frame from a Dropdown under that root instance, we have to be careful to align the absoluteposition and size. This feels a bit hacky and isn't ideal but appears to be robust nonetheless.