### PR TITLE
Overhaul TextInput's API.

### DIFF
--- a/src/TextInput.ParseValue.story.lua
+++ b/src/TextInput.ParseValue.story.lua
@@ -1,0 +1,64 @@
+local Packages = script.Parent.Parent
+local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
+
+local TextInput = require(script.Parent.TextInput)
+local Label = require(script.Parent.Label)
+
+local function Helper(props, hooks)
+	local parsingError, setParsingError = hooks.useState()
+	local number, setNumber = hooks.useState(0)
+
+	return Roact.createElement("Frame", {
+		AnchorPoint = Vector2.new(0.5, 0.5),
+		Position = UDim2.fromScale(0.5, 0.5),
+		Size = UDim2.fromScale(0.7, 0.7),
+		BackgroundTransparency = 1,
+	}, {
+		Layout = Roact.createElement("UIListLayout", {
+			Padding = UDim.new(0, 5),
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			FillDirection = Enum.FillDirection.Vertical,
+			HorizontalAlignment = Enum.HorizontalAlignment.Center,
+			VerticalAlignment = Enum.VerticalAlignment.Center,
+		}),
+		StatusText = Roact.createElement(Label, {
+			Size = UDim2.new(1, 0, 0, 21),
+			LayoutOrder = 0,
+			Text = parsingError or "Valid number!",
+			TextColorStyle = if parsingError then Enum.StudioStyleGuideColor.ErrorText else nil,
+		}),
+		Input = Roact.createElement(TextInput, {
+			Value = number,
+			PlaceholderText = "Enabled",
+			LayoutOrder = 1,
+			TryParsing = function(text)
+				local value = tonumber(text)
+
+				if value then
+					return true, value
+				else
+					return false, "Invalid number!"
+				end
+			end,
+			OnChangedInvalid = setParsingError,
+			OnChanged = function(value)
+				if error then
+					setParsingError(Roact.None)
+				end
+
+				setNumber(value)
+			end,
+		}),
+	})
+end
+
+Helper = Hooks.new(Roact)(Helper)
+
+return function(target)
+	local element = Roact.createElement(Helper)
+	local handle = Roact.mount(element, target)
+	return function()
+		Roact.unmount(handle)
+	end
+end

--- a/src/TextInput.ParseValue.story.lua
+++ b/src/TextInput.ParseValue.story.lua
@@ -30,6 +30,7 @@ local function Helper(props, hooks)
 		}),
 		Input = Roact.createElement(TextInput, {
 			Value = number,
+			ResetOnInvalid = true,
 			PlaceholderText = "Enabled",
 			LayoutOrder = 1,
 			TryParsing = function(text)
@@ -43,7 +44,7 @@ local function Helper(props, hooks)
 			end,
 			OnChangedInvalid = setParsingError,
 			OnChanged = function(value)
-				if error then
+				if parsingError then
 					setParsingError(Roact.None)
 				end
 

--- a/src/TextInput.lua
+++ b/src/TextInput.lua
@@ -19,8 +19,11 @@ TextInput.defaultProps = {
 	Value = "",
 	PlaceholderText = "",
 	Stringify = tostring,
-	TryParsing = function(value) return true, value end,
+	TryParsing = function(value)
+		return true, value
+	end,
 	ClearTextOnFocus = true,
+	ResetOnInvalid = true,
 	OnFocused = noop,
 	OnFocusLost = noop,
 	OnFocusLostInvalid = noop,
@@ -64,8 +67,12 @@ function TextInput:init()
 
 		if success then
 			self.props.OnFocusLost(value, enterPressed, inputObject)
-		else
+		elseif not self.props.ResetOnInvalid then
 			self.props.OnFocusLostInvalid(value, enterPressed, inputObject)
+		end
+
+		if self.props.ResetOnInvalid then
+			rbx.Text = self:getTextFromValue()
 		end
 	end
 	self.onChanged = function(rbx)
@@ -77,6 +84,11 @@ function TextInput:init()
 			self.props.OnChangedInvalid(value, rbx.Text)
 		end
 	end
+end
+
+function TextInput:getTextFromValue()
+	-- TODO: Get rid of self.props.Text for self.props.Value.
+	return self.props.Stringify(self.props.Value or self.props.Text)
 end
 
 function TextInput:render()
@@ -103,8 +115,7 @@ function TextInput:render()
 			BorderMode = Enum.BorderMode.Inset,
 			LayoutOrder = self.props.LayoutOrder,
 			Font = Constants.Font,
-			-- TODO: Get rid of self.props.Text for self.props.Value.
-			Text = self.props.Text or self.props.Value,
+			Text = self:getTextFromValue(),
 			TextSize = Constants.TextSize,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, mainModifier),
 			TextXAlignment = Enum.TextXAlignment.Left,

--- a/src/TextInput.lua
+++ b/src/TextInput.lua
@@ -23,7 +23,7 @@ TextInput.defaultProps = {
 	ClearTextOnFocus = true,
 	OnFocused = noop,
 	OnFocusLost = noop,
-	OnInvalidFocusLost = noop,
+	OnFocusLostInvalid = noop,
 	OnChanged = noop,
 	OnChangedInvalid = noop,
 }

--- a/src/TextInput.lua
+++ b/src/TextInput.lua
@@ -104,7 +104,7 @@ function TextInput:render()
 			LayoutOrder = self.props.LayoutOrder,
 			Font = Constants.Font,
 			-- TODO: Get rid of self.props.Text for self.props.Value.
-			Text = self.props.Value or self.props.Text,
+			Text = self.props.Text or self.props.Value,
 			TextSize = Constants.TextSize,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, mainModifier),
 			TextXAlignment = Enum.TextXAlignment.Left,

--- a/src/TextInput.story.lua
+++ b/src/TextInput.story.lua
@@ -25,7 +25,7 @@ return function(target)
 			LayoutOrder = 1,
 			Disabled = true,
 			PlaceholderText = "Disabled",
-			Text = "Disabled",
+			Value = "Disabled",
 		}),
 	})
 	local handle = Roact.mount(element, target)


### PR DESCRIPTION
Closes #10 and closes #18.

This change is backward compatible. **However**, it deprecates the use of `Text`, preferring `Value` instead! This change adds the suggested API from #18 to TextInput instead of a separate component.

I'm not sure if `OnFocusLostInvalid` is required since OnChangedInvalid exists. However, text has been passed to `OnFocusLost` previously which ***now** could be* invalid. 

In the future, `Text` should be completely removed in a future major release.

This change allow us to implement #9 or any other formatted text input with ease as seen in the example story.