### PR TITLE
Implement Tooltip

### DIFF
--- a/src/Checkbox.lua
+++ b/src/Checkbox.lua
@@ -10,8 +10,6 @@ local Constants = require(script.Parent.Constants)
 local INDICATOR_IMAGE = "rbxassetid://6652838434"
 
 local defaultProps = {
-	LayoutOrder = 0,
-	Disabled = false,
 	Alignment = Constants.CheckboxAlignment.Left,
 }
 
@@ -82,6 +80,7 @@ local function Checkbox(props, hooks)
 		Size = UDim2.new(1, 0, 0, 15),
 		BackgroundTransparency = 1,
 		LayoutOrder = props.LayoutOrder,
+		ZIndex = props.ZIndex,
 	}, {
 		Button = Roact.createElement("TextButton", {
 			Text = "",
@@ -121,6 +120,7 @@ local function Checkbox(props, hooks)
 			TextSize = Constants.TextSize,
 			TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText, mainModifier),
 		}),
+		Children = Roact.createFragment(props[Roact.Children]),
 	})
 end
 

--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -8,4 +8,9 @@ return {
 		Right = "Right",
 	},
 	CheckboxIndeterminate = "Indeterminate",
+
+	ZIndex = {
+		Dropdown = 2 ^ 31 - 2,
+		Tooltip = 2 ^ 31 - 1,
+	},
 }

--- a/src/Dropdown/init.lua
+++ b/src/Dropdown/init.lua
@@ -134,7 +134,7 @@ local function Dropdown(props, hooks)
 				target = target,
 			}, {
 				Frame = Roact.createElement("Frame", {
-					ZIndex = 2 ^ 31 - 1,
+					ZIndex = Constants.ZIndex.Dropdown,
 					BackgroundTransparency = 1,
 					Size = UDim2.fromScale(1, 1),
 					[Roact.Event.InputBegan] = onCatcherInputBegan,
@@ -205,6 +205,7 @@ local function Dropdown(props, hooks)
 				ImageColor3 = theme:GetColor(Enum.StudioStyleGuideColor.TitlebarText, modifier),
 			}),
 		}),
+		Children = Roact.createFragment(props[Roact.Children]),
 	})
 end
 

--- a/src/Label.lua
+++ b/src/Label.lua
@@ -9,11 +9,6 @@ local joinDictionaries = require(script.Parent.joinDictionaries)
 local Constants = require(script.Parent.Constants)
 
 local defaultProps = {
-	LayoutOrder = 0,
-	ZIndex = 0,
-	Disabled = false,
-	Position = UDim2.fromScale(0, 0),
-	AnchorPoint = Vector2.new(0, 0),
 	Size = UDim2.fromScale(1, 1),
 	Text = "Label.defaultProps.Text",
 	Font = Constants.Font,

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -22,7 +22,7 @@ local OFFSET_UP = 2
 local defaultProps = {
 	Text = "Tooltip.defaultProps.Text",
 	MaxWidth = 200,
-	HoverDelay = 0.5,
+	HoverDelay = 0.4,
 }
 
 -- TODO: do some kind of validation if the trigger has moved e.g. in a scroll frame?
@@ -117,33 +117,36 @@ local function Tooltip(props, hooks)
 		end
 	end
 
-	local dropShadow = Roact.createElement(Shadow, {
-		Position = UDim2.fromOffset(4, 4),
-		Size = UDim2.new(1, 1, 1, 1),
-		Radius = 5,
-		Transparency = 0.96,
-	}, {
-		Shadow = Roact.createElement(Shadow, {
-			Position = UDim2.fromOffset(1, 1),
-			Size = UDim2.new(1, -2, 1, -2),
-			Radius = 4,
-			Transparency = 0.88,
+	local dropShadow = nil
+	if target ~= nil then
+		dropShadow = Roact.createElement(Shadow, {
+			Position = UDim2.fromOffset(4, 4),
+			Size = UDim2.new(1, 1, 1, 1),
+			Radius = 5,
+			Transparency = 0.96,
 		}, {
 			Shadow = Roact.createElement(Shadow, {
 				Position = UDim2.fromOffset(1, 1),
 				Size = UDim2.new(1, -2, 1, -2),
-				Radius = 3,
-				Transparency = 0.80,
+				Radius = 4,
+				Transparency = 0.88,
 			}, {
 				Shadow = Roact.createElement(Shadow, {
 					Position = UDim2.fromOffset(1, 1),
 					Size = UDim2.new(1, -2, 1, -2),
-					Radius = 2,
-					Transparency = 0.77,
+					Radius = 3,
+					Transparency = 0.80,
+				}, {
+					Shadow = Roact.createElement(Shadow, {
+						Position = UDim2.fromOffset(1, 1),
+						Size = UDim2.new(1, -2, 1, -2),
+						Radius = 2,
+						Transparency = 0.77,
+					}),
 				}),
 			}),
-		}),
-	})
+		})
+	end
 
 	return Roact.createElement("Frame", {
 		Size = UDim2.fromScale(1, 1),

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -14,6 +14,11 @@ local TEXT_PADDING_SIDES = 3
 local TEXT_PADDING_TOP = 1
 local TEXT_PADDING_BTM = 2
 
+local OFFSET_RIGHT = 3
+local OFFSET_DOWN = 18
+local OFFSET_LEFT = 2
+local OFFSET_UP = 2
+
 local defaultProps = {
 	Text = "Tooltip.defaultProps.Text",
 	MaxWidth = 200,
@@ -84,12 +89,31 @@ local function Tooltip(props, hooks)
 
 	local frameSize = Vector2.new(props.MaxWidth - TEXT_PADDING_SIDES * 2, math.huge)
 	local textSize = TextService:GetTextSize(props.Text, TEXT_SIZE, FONT, frameSize)
+	local fullSize = textSize + Vector2.new(TEXT_PADDING_SIDES * 2, TEXT_PADDING_BTM + TEXT_PADDING_TOP)
+	local buffer = 3 -- extra space required around/above/below
 
 	local target = nil
+	local anchor = Vector2.new(0, 0)
+	local offset = Vector2.new(OFFSET_RIGHT, OFFSET_DOWN)
 	if display and dummyRef.value then
 		local inst = dummyRef.value:getValue()
 		if inst ~= nil then
 			target = inst:FindFirstAncestorWhichIsA("LayerCollector")
+			local mouse = displayPos.value
+			if target ~= nil then
+				local spaceRight = target.AbsoluteSize.x - mouse.x - OFFSET_RIGHT
+				local spaceLeft = mouse.x - OFFSET_LEFT
+				if spaceRight < fullSize.x + buffer and spaceLeft > spaceRight then
+					anchor = Vector2.new(1, anchor.y)
+					offset = Vector2.new(-OFFSET_LEFT, offset.y)
+				end
+				local spaceBelow = target.AbsoluteSize.y - mouse.y - OFFSET_DOWN
+				local spaceAbove = mouse.y - OFFSET_UP
+				if spaceBelow < fullSize.y + buffer and spaceAbove > spaceBelow then
+					anchor = Vector2.new(anchor.x, 1)
+					offset = Vector2.new(offset.x, -OFFSET_UP)
+				end
+			end
 		end
 	end
 
@@ -135,11 +159,9 @@ local function Tooltip(props, hooks)
 			Tooltip = Roact.createElement("Frame", {
 				ZIndex = Constants.ZIndex.Tooltip,
 				BackgroundTransparency = 1,
-				Size = UDim2.fromOffset(
-					textSize.x + TEXT_PADDING_SIDES * 2,
-					textSize.y + TEXT_PADDING_TOP + TEXT_PADDING_BTM
-				),
-				Position = UDim2.fromOffset(displayPos.value.x + 3, displayPos.value.y + 18),
+				Size = UDim2.fromOffset(fullSize.x, fullSize.y),
+				AnchorPoint = anchor,
+				Position = UDim2.fromOffset(displayPos.value.x + offset.x, displayPos.value.y + offset.y),
 			}, {
 				Label = Roact.createElement("TextLabel", {
 					ZIndex = 1,

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -26,7 +26,6 @@ local defaultProps = {
 }
 
 -- TODO: do some kind of validation if the trigger has moved e.g. in a scroll frame?
--- TODO: disabled?
 
 local function Shadow(props, hooks)
 	local theme = useTheme(hooks)
@@ -66,6 +65,9 @@ local function Tooltip(props, hooks)
 	end
 
 	local function onInputBeganChanged(_, input)
+		if props.Disabled then
+			return
+		end
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
 			cancel()
 			displayPos.value = Vector2.new(input.Position.x, input.Position.y)

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -1,0 +1,174 @@
+local TextService = game:GetService("TextService")
+
+local Packages = script.Parent.Parent
+
+local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
+
+local Constants = require(script.Parent.Constants)
+local useTheme = require(script.Parent.useTheme)
+
+local FONT = Constants.Font
+local TEXT_SIZE = 14
+local TEXT_PADDING_SIDES = 3
+local TEXT_PADDING_TOP = 1
+local TEXT_PADDING_BTM = 2
+
+local defaultProps = {
+	Text = "Tooltip.defaultProps.Text",
+	MaxWidth = 200,
+	HoverDelay = 0.5,
+}
+
+-- TODO: make sure visible above a dropdown
+-- TODO: do some kind of validation if the trigger has moved e.g. in a scroll frame?
+-- TODO: disabled?
+
+local function Shadow(props, hooks)
+	local theme = useTheme(hooks)
+	return Roact.createElement("Frame", {
+		BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.DropShadow),
+		BackgroundTransparency = props.Transparency,
+		BorderSizePixel = 0,
+		Position = props.Position,
+		Size = props.Size,
+		ZIndex = 0,
+	}, {
+		Corner = Roact.createElement("UICorner", {
+			CornerRadius = UDim.new(0, props.Radius),
+		}),
+		Children = Roact.createFragment(props[Roact.Children]),
+	})
+end
+Shadow = Hooks.new(Roact)(Shadow)
+
+local function Tooltip(props, hooks)
+	local theme = useTheme(hooks)
+	local dummyRef = hooks.useValue(Roact.createRef())
+
+	local display, setDisplay = hooks.useState(false)
+	local displayPos = hooks.useValue(nil)
+	local displayThread = hooks.useValue(nil)
+
+	local function cancel()
+		if display == true then
+			setDisplay(false)
+		end
+		if displayThread.value then
+			task.cancel(displayThread.value)
+			displayThread.value = nil
+			displayPos.value = nil
+		end
+	end
+
+	local function onInputBeganChanged(_, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			cancel()
+			displayPos.value = Vector2.new(input.Position.x, input.Position.y)
+			displayThread.value = task.delay(props.HoverDelay, function()
+				setDisplay(true)
+			end)
+		end
+	end
+
+	local function onInputEnded(_, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			cancel()
+		end
+	end
+
+	hooks.useEffect(function()
+		if displayThread.value then
+			task.cancel(displayThread.value)
+		end
+	end, {})
+
+	local frameSize = Vector2.new(props.MaxWidth - TEXT_PADDING_SIDES * 2, math.huge)
+	local textSize = TextService:GetTextSize(props.Text, TEXT_SIZE, FONT, frameSize)
+
+	local target = nil
+	if display and dummyRef.value then
+		local inst = dummyRef.value:getValue()
+		if inst ~= nil then
+			target = inst:FindFirstAncestorWhichIsA("LayerCollector")
+		end
+	end
+
+	local dropShadow = Roact.createElement(Shadow, {
+		Position = UDim2.fromOffset(4, 4),
+		Size = UDim2.new(1, 1, 1, 1),
+		Radius = 5,
+		Transparency = 0.96,
+	}, {
+		Shadow = Roact.createElement(Shadow, {
+			Position = UDim2.fromOffset(1, 1),
+			Size = UDim2.new(1, -2, 1, -2),
+			Radius = 4,
+			Transparency = 0.88,
+		}, {
+			Shadow = Roact.createElement(Shadow, {
+				Position = UDim2.fromOffset(1, 1),
+				Size = UDim2.new(1, -2, 1, -2),
+				Radius = 3,
+				Transparency = 0.80,
+			}, {
+				Shadow = Roact.createElement(Shadow, {
+					Position = UDim2.fromOffset(1, 1),
+					Size = UDim2.new(1, -2, 1, -2),
+					Radius = 2,
+					Transparency = 0.77,
+				}),
+			}),
+		}),
+	})
+
+	return Roact.createElement("Frame", {
+		Size = UDim2.fromScale(1, 1),
+		BackgroundTransparency = 1,
+		[Roact.Ref] = dummyRef.value,
+		[Roact.Event.InputBegan] = onInputBeganChanged,
+		[Roact.Event.InputChanged] = onInputBeganChanged,
+		[Roact.Event.InputEnded] = onInputEnded,
+	}, {
+		Portal = target and Roact.createElement(Roact.Portal, {
+			target = target,
+		}, {
+			Tooltip = Roact.createElement("Frame", {
+				ZIndex = 2 ^ 16 - 1,
+				BackgroundTransparency = 1,
+				Size = UDim2.fromOffset(
+					textSize.x + TEXT_PADDING_SIDES * 2,
+					textSize.y + TEXT_PADDING_TOP + TEXT_PADDING_BTM
+				),
+				Position = UDim2.fromOffset(displayPos.value.x + 3, displayPos.value.y + 18),
+			}, {
+				Label = Roact.createElement("TextLabel", {
+					ZIndex = 1,
+					Size = UDim2.fromScale(1, 1),
+					BackgroundTransparency = 0,
+					Text = props.Text,
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextYAlignment = Enum.TextYAlignment.Top,
+					Font = Enum.Font.SourceSans,
+					TextSize = 14,
+					TextWrapped = true,
+					BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Tooltip),
+					BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
+					TextColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainText),
+				}, {
+					Padding = Roact.createElement("UIPadding", {
+						PaddingLeft = UDim.new(0, TEXT_PADDING_SIDES),
+						PaddingRight = UDim.new(0, TEXT_PADDING_SIDES),
+						PaddingTop = UDim.new(0, TEXT_PADDING_TOP),
+						PaddingBottom = UDim.new(0, TEXT_PADDING_BTM),
+					}),
+				}),
+				Shadow = dropShadow,
+			}),
+		}),
+	})
+end
+
+return Hooks.new(Roact)(Tooltip, {
+	defaultProps = defaultProps,
+})

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -20,7 +20,6 @@ local defaultProps = {
 	HoverDelay = 0.5,
 }
 
--- TODO: make sure visible above a dropdown
 -- TODO: do some kind of validation if the trigger has moved e.g. in a scroll frame?
 -- TODO: disabled?
 
@@ -134,7 +133,7 @@ local function Tooltip(props, hooks)
 			target = target,
 		}, {
 			Tooltip = Roact.createElement("Frame", {
-				ZIndex = 2 ^ 16 - 1,
+				ZIndex = Constants.ZIndex.Tooltip,
 				BackgroundTransparency = 1,
 				Size = UDim2.fromOffset(
 					textSize.x + TEXT_PADDING_SIDES * 2,

--- a/src/Tooltip.lua
+++ b/src/Tooltip.lua
@@ -25,8 +25,6 @@ local defaultProps = {
 	HoverDelay = 0.4,
 }
 
--- TODO: do some kind of validation if the trigger has moved e.g. in a scroll frame?
-
 local function Shadow(props, hooks)
 	local theme = useTheme(hooks)
 	return Roact.createElement("Frame", {
@@ -157,6 +155,7 @@ local function Tooltip(props, hooks)
 		[Roact.Event.InputBegan] = onInputBeganChanged,
 		[Roact.Event.InputChanged] = onInputBeganChanged,
 		[Roact.Event.InputEnded] = onInputEnded,
+		[Roact.Change.AbsolutePosition] = cancel,
 	}, {
 		Portal = target and Roact.createElement(Roact.Portal, {
 			target = target,

--- a/src/Tooltip.story.lua
+++ b/src/Tooltip.story.lua
@@ -1,0 +1,34 @@
+local Packages = script.Parent.Parent
+local Roact = require(Packages.Roact)
+
+local Tooltip = require(script.Parent.Tooltip)
+
+local Button = require(script.Parent.Button)
+
+return function(target)
+	local element = Roact.createFragment({
+		Layout = Roact.createElement("UIListLayout", {
+			Padding = UDim.new(0, 10),
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			FillDirection = Enum.FillDirection.Vertical,
+			HorizontalAlignment = Enum.HorizontalAlignment.Center,
+			VerticalAlignment = Enum.VerticalAlignment.Center,
+		}),
+
+		Button = Roact.createElement(Button, {
+			LayoutOrder = 0,
+			AnchorPoint = Vector2.new(0.5, 0.5),
+			Position = UDim2.fromScale(0.5, 0.5),
+			Size = UDim2.fromOffset(200, 40),
+			Text = "Example button",
+		}, {
+			Tooltip = Roact.createElement(Tooltip, {
+				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+			}),
+		}),
+	})
+	local handle = Roact.mount(element, target)
+	return function()
+		Roact.unmount(handle)
+	end
+end

--- a/src/Tooltip.story.lua
+++ b/src/Tooltip.story.lua
@@ -4,6 +4,7 @@ local Roact = require(Packages.Roact)
 local Tooltip = require(script.Parent.Tooltip)
 
 local Button = require(script.Parent.Button)
+local Checkbox = require(script.Parent.Checkbox)
 
 return function(target)
 	local element = Roact.createFragment({
@@ -24,6 +25,23 @@ return function(target)
 		}, {
 			Tooltip = Roact.createElement(Tooltip, {
 				Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+			}),
+		}),
+
+		Checkbox = Roact.createElement("Frame", {
+			LayoutOrder = 1,
+			Size = UDim2.fromOffset(120, 16),
+			BackgroundTransparency = 1,
+		}, {
+			Actual = Roact.createElement(Checkbox, {
+				Value = true,
+				Label = "Example checkbox",
+				OnActivated = function() end,
+			}, {
+				Tooltip = Roact.createElement(Tooltip, {
+					Text = "This is an explanation of the checkbox",
+					HoverDelay = 0.5,
+				}),
 			}),
 		}),
 	})

--- a/src/Tooltip.story.lua
+++ b/src/Tooltip.story.lua
@@ -6,6 +6,7 @@ local Tooltip = require(script.Parent.Tooltip)
 local Button = require(script.Parent.Button)
 local Checkbox = require(script.Parent.Checkbox)
 local Dropdown = require(script.Parent.Dropdown)
+local Label = require(script.Parent.Label)
 
 return function(target)
 	local element = Roact.createFragment({
@@ -55,6 +56,16 @@ return function(target)
 		}, {
 			Tooltip = Roact.createElement(Tooltip, {
 				Text = "This is an explanation of the dropdown",
+			}),
+		}),
+
+		Label = Roact.createElement(Label, {
+			LayoutOrder = 3,
+			Size = UDim2.fromOffset(80, 14),
+			Text = "Example label",
+		}, {
+			Tooltip = Roact.createElement(Tooltip, {
+				Text = "This is an explanation of the label",
 			}),
 		}),
 	})

--- a/src/Tooltip.story.lua
+++ b/src/Tooltip.story.lua
@@ -7,8 +7,22 @@ local Button = require(script.Parent.Button)
 local Checkbox = require(script.Parent.Checkbox)
 local Dropdown = require(script.Parent.Dropdown)
 local Label = require(script.Parent.Label)
+local ScrollFrame = require(script.Parent.ScrollFrame)
 
 return function(target)
+	local scrollContents = {}
+	for i = 1, 10 do
+		scrollContents[i] = Roact.createElement(Label, {
+			LayoutOrder = i,
+			Size = UDim2.new(1, 0, 0, 20),
+			Text = "Label " .. i,
+		}, {
+			Tooltip = Roact.createElement(Tooltip, {
+				Text = "Tooltip for Label " .. i,
+			}),
+		})
+	end
+
 	local element = Roact.createFragment({
 		Layout = Roact.createElement("UIListLayout", {
 			Padding = UDim.new(0, 10),
@@ -68,6 +82,14 @@ return function(target)
 				Text = "This is an explanation of the label",
 			}),
 		}),
+
+		ScrollFrame = Roact.createElement(ScrollFrame, {
+			LayoutOrder = 4,
+			Size = UDim2.fromOffset(175, 80),
+			Layout = {
+				Padding = UDim.new(0, 0),
+			},
+		}, scrollContents),
 	})
 	local handle = Roact.mount(element, target)
 	return function()

--- a/src/Tooltip.story.lua
+++ b/src/Tooltip.story.lua
@@ -5,6 +5,7 @@ local Tooltip = require(script.Parent.Tooltip)
 
 local Button = require(script.Parent.Button)
 local Checkbox = require(script.Parent.Checkbox)
+local Dropdown = require(script.Parent.Dropdown)
 
 return function(target)
 	local element = Roact.createFragment({
@@ -40,8 +41,20 @@ return function(target)
 			}, {
 				Tooltip = Roact.createElement(Tooltip, {
 					Text = "This is an explanation of the checkbox",
-					HoverDelay = 0.5,
 				}),
+			}),
+		}),
+
+		Dropdown = Roact.createElement(Dropdown, {
+			LayoutOrder = 2,
+			Width = UDim.new(0, 120),
+			Items = { "OptionA", "OptionB", "OptionC", "OptionD", "OptionE", "OptionF" },
+			MaxVisibleRows = 4,
+			SelectedItem = "OptionA",
+			OnItemSelected = function() end,
+		}, {
+			Tooltip = Roact.createElement(Tooltip, {
+				Text = "This is an explanation of the dropdown",
 			}),
 		}),
 	})

--- a/src/init.lua
+++ b/src/init.lua
@@ -9,6 +9,7 @@ return {
 	ScrollFrame = require(script.ScrollFrame),
 	Slider = require(script.Slider),
 	TextInput = require(script.TextInput),
+	Tooltip = require(script.Tooltip),
 	VerticalCollapsibleSection = require(script.VerticalCollapsibleSection),
 	VerticalExpandingList = require(script.VerticalExpandingList),
 	Widget = require(script.Widget),


### PR DESCRIPTION
This PR implements a new component for tooltips:
- Designed to match the look and behavior of Studio's built-in tooltips: a tooltip will appear after a delay of the mouse hovering in the same location over the host instance. See the story file for further explanation.
- Renders on top of all other UI under the same layercollector, including expanded dropdowns.
- Renders below-right of the mouse by default unless there is not enough space, in which case they can go to the left, above, or both.

![image](https://user-images.githubusercontent.com/25118482/192601999-c223c0bb-9164-46c5-ad7d-034756bf2443.png)

Note: not all components support Tooltip yet (e.g. Slider). These should be relatively small changes to make.