### PR TITLE
TabContainer now resembles Studio's Tab more closely.

### DIFF
--- a/src/TabContainer/TabButton.lua
+++ b/src/TabContainer/TabButton.lua
@@ -29,6 +29,9 @@ local function TabButton(props, hooks)
 	end
 
 	local color = Enum.StudioStyleGuideColor.Button
+	if props.Selected then
+		color = Enum.StudioStyleGuideColor.MainBackground
+	end
 	local modifier = Enum.StudioStyleGuideModifier.Default
 	if props.Disabled then
 		modifier = Enum.StudioStyleGuideModifier.Disabled
@@ -60,11 +63,9 @@ local function TabButton(props, hooks)
 		end,
 	}, {
 		Indicator = props.Selected and Roact.createElement("Frame", {
-			AnchorPoint = Vector2.new(0, 1),
 			BackgroundColor3 = Color3.fromRGB(0, 162, 255),
 			BackgroundTransparency = props.Disabled and 0.8 or 0,
 			BorderSizePixel = 0,
-			Position = UDim2.fromScale(0, 1),
 			Size = UDim2.new(1, 0, 0, 2),
 		}),
 	})

--- a/src/TabContainer/init.lua
+++ b/src/TabContainer/init.lua
@@ -12,12 +12,17 @@ local function TabContainer(props, hooks)
 	local theme = useTheme(hooks)
 
 	local tabs = {}
+	local selectedTabIndex
 	for i, tab in ipairs(props.Tabs) do
+		local isSelectedTab = props.SelectedTab == tab.Name
+		if isSelectedTab then
+			selectedTabIndex = i
+		end
 		tabs[i] = Roact.createElement(TabButton, {
 			Size = UDim2.fromScale(1 / #props.Tabs, 1),
 			LayoutOrder = i,
 			Text = tab.Name,
-			Selected = props.SelectedTab == tab.Name,
+			Selected = isSelectedTab,
 			Disabled = tab.Disabled,
 			OnActivated = function()
 				props.OnTabSelected(tab.Name)
@@ -47,11 +52,24 @@ local function TabContainer(props, hooks)
 			Size = UDim2.new(1, 0, 0, TAB_HEIGHT),
 			BackgroundTransparency = 1,
 		}, {
-			Layout = Roact.createElement("UIListLayout", {
-				SortOrder = Enum.SortOrder.LayoutOrder,
-				FillDirection = Enum.FillDirection.Horizontal,
+			BridgeToSelected = selectedTabIndex and Roact.createElement("Frame", {
+				BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.MainBackground),
+				BorderSizePixel = 0,
+				-- We do not want to cover the leftmost border-size in-between the tabs. Hence, subtracting one pixel (which is the width of the border).
+				-- However, on the very end, we want to cover that border since there's no tabs to divide against.
+				Size = UDim2.new(1 / #props.Tabs, if selectedTabIndex == #props.Tabs then 0 else -1, 0, 1),
+				Position = UDim2.new(1 / #props.Tabs * (selectedTabIndex - 1), 0, 1, 0),
 			}),
-			Tabs = Roact.createFragment(tabs),
+			TabsContainer = Roact.createElement("Frame", {
+				Size = UDim2.fromScale(1, 1),
+				BackgroundTransparency = 1,
+			}, {
+				Tabs = Roact.createFragment(tabs),
+				Layout = Roact.createElement("UIListLayout", {
+					SortOrder = Enum.SortOrder.LayoutOrder,
+					FillDirection = Enum.FillDirection.Horizontal,
+				}),
+			}),
 		}),
 		Content = Roact.createElement("Frame", {
 			ZIndex = 1,


### PR DESCRIPTION
Better match Studio's Tabs by:
- moving the indicator up;
- changing the tab button's selected background to be the main background;
- and filling the border gap on said tab button.