### PR TITLE
Implement Splitter

### DIFF
--- a/src/Constants.lua
+++ b/src/Constants.lua
@@ -9,6 +9,11 @@ return {
 	},
 	CheckboxIndeterminate = "Indeterminate",
 
+	SplitterOrientation = {
+		Horizontal = "Horizontal",
+		Vertical = "Vertical",
+	},
+
 	ZIndex = {
 		Dropdown = 2 ^ 31 - 2,
 		Tooltip = 2 ^ 31 - 1,

--- a/src/PluginContext.lua
+++ b/src/PluginContext.lua
@@ -1,0 +1,4 @@
+local Packages = script.Parent.Parent
+local Roact = require(Packages.Roact)
+
+return Roact.createContext()

--- a/src/PluginProvider.lua
+++ b/src/PluginProvider.lua
@@ -1,0 +1,50 @@
+local HttpService = game:GetService("HttpService")
+
+local Packages = script.Parent.Parent
+
+local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
+
+local PluginContext = require(script.Parent.PluginContext)
+
+local function PluginProvider(props, hooks)
+	local plugin = props.Plugin
+	local iconStack = hooks.useValue({})
+
+	local function updateMouseIcon()
+		local top = iconStack.value[#iconStack.value]
+		plugin:GetMouse().Icon = if top then top.icon else ""
+	end
+
+	local function pushMouseIcon(icon)
+		local id = HttpService:GenerateGUID(false)
+		table.insert(iconStack.value, { id = id, icon = icon })
+		updateMouseIcon()
+		return id
+	end
+
+	local function popMouseIcon(id)
+		for i = #iconStack.value, 1, -1 do
+			local item = iconStack.value[i]
+			if item.id == id then
+				table.remove(iconStack.value, i)
+			end
+		end
+		updateMouseIcon()
+	end
+
+	-- TODO: unset icon on unmount?
+	-- hooks.useEffect(function()
+	--	 updateMouseIcon()
+	-- end)
+
+	return Roact.createElement(PluginContext.Provider, {
+		value = {
+			plugin = plugin,
+			pushMouseIcon = pushMouseIcon,
+			popMouseIcon = popMouseIcon,
+		},
+	}, props[Roact.Children])
+end
+
+return Hooks.new(Roact)(PluginProvider)

--- a/src/PluginProvider.lua
+++ b/src/PluginProvider.lua
@@ -7,6 +7,8 @@ local Hooks = require(Packages.RoactHooks)
 
 local PluginContext = require(script.Parent.PluginContext)
 
+-- consumers that set mouse icon are responsible for unsetting on unmount
+
 local function PluginProvider(props, hooks)
 	local plugin = props.Plugin
 	local iconStack = hooks.useValue({})
@@ -32,11 +34,6 @@ local function PluginProvider(props, hooks)
 		end
 		updateMouseIcon()
 	end
-
-	-- TODO: unset icon on unmount?
-	-- hooks.useEffect(function()
-	--	 updateMouseIcon()
-	-- end)
 
 	return Roact.createElement(PluginContext.Provider, {
 		value = {

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -28,6 +28,16 @@ local function safeClamp(value, min, max)
 	return math.min(math.max(value, min), max)
 end
 
+local function maybeFlip(shouldFlip, value)
+	if not shouldFlip then
+		return value
+	elseif typeof(value) == "Vector2" then
+		return Vector2.new(value.Y, value.X)
+	elseif typeof(value) == "UDim2" then
+		return UDim2.new(value.Height, value.Width)
+	end
+end
+
 local function Splitter(props, hooks)
 	local theme = useTheme(hooks)
 	local plugin = usePlugin(hooks)
@@ -87,23 +97,8 @@ local function Splitter(props, hooks)
 	end, {})
 
 	local alpha = safeClamp(props.Alpha, props.MinAlpha, props.MaxAlpha)
-
-	local size0 = UDim2.new(alpha, -HANDLE_THICKNESS / 2, 1, 0)
-	local size1 = UDim2.new(1 - alpha, -HANDLE_THICKNESS / 2, 1, 0)
-	local anchor1 = Vector2.new(1, 0)
-	local position1 = UDim2.fromScale(1, 0)
-	local barAnchorPoint = Vector2.new(0.5, 0)
-	local barPosition = UDim2.fromScale(alpha, 0)
-	local barSize = UDim2.new(0, HANDLE_THICKNESS, 1, 0)
-	if props.Orientation == Constants.SplitterOrientation.Horizontal then
-		size0 = UDim2.new(size0.Height, size0.Width)
-		size1 = UDim2.new(size1.Height, size1.Width)
-		anchor1 = Vector2.new(anchor1.y, anchor1.x)
-		position1 = UDim2.new(position1.Height, position1.Width)
-		barAnchorPoint = Vector2.new(barAnchorPoint.y, barAnchorPoint.x)
-		barPosition = UDim2.new(barPosition.Height, barPosition.Width)
-		barSize = UDim2.new(barSize.Height, barSize.Width)
-	end
+	local barColor = theme:GetColor(Enum.StudioStyleGuideColor.DialogButton)
+	local flip = props.Orientation ~= Constants.SplitterOrientation.Vertical
 
 	return Roact.createElement("Frame", {
 		Size = props.Size,
@@ -115,15 +110,15 @@ local function Splitter(props, hooks)
 		[Roact.Ref] = containerRef.value,
 	}, {
 		Side0 = Roact.createElement("Frame", {
-			Size = size0,
+			Size = maybeFlip(flip, UDim2.new(alpha, -HANDLE_THICKNESS / 2, 1, 0)),
 			BackgroundTransparency = 1,
 			ZIndex = 0,
 			ClipsDescendants = true,
 		}, { Content = props[Roact.Children][1] }),
 		Side1 = Roact.createElement("Frame", {
-			AnchorPoint = anchor1,
-			Position = position1,
-			Size = size1,
+			AnchorPoint = maybeFlip(flip, Vector2.new(1, 0)),
+			Position = maybeFlip(flip, UDim2.fromScale(1, 0)),
+			Size = maybeFlip(flip, UDim2.new(1 - alpha, -HANDLE_THICKNESS / 2, 1, 0)),
 			BackgroundTransparency = 1,
 			ZIndex = 0,
 			ClipsDescendants = true,
@@ -132,10 +127,10 @@ local function Splitter(props, hooks)
 			Active = false,
 			AutoButtonColor = false,
 			Text = "",
-			AnchorPoint = barAnchorPoint,
-			Position = barPosition,
-			Size = barSize,
-			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.DialogButton),
+			AnchorPoint = maybeFlip(flip, Vector2.new(0.5, 0)),
+			Position = maybeFlip(flip, UDim2.fromScale(alpha, 0)),
+			Size = maybeFlip(flip, UDim2.new(0, HANDLE_THICKNESS, 1, 0)),
+			BackgroundColor3 = barColor,
 			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
 			BackgroundTransparency = props.Disabled and 0.75 or 0,
 			ZIndex = 1,

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -53,7 +53,10 @@ local function Splitter(props, hooks)
 			safeClamp(relative.x, props.MinAlpha, props.MaxAlpha),
 			safeClamp(relative.y, props.MinAlpha, props.MaxAlpha)
 		)
-		props.OnAlphaChanged(if props.Orientation == Constants.SplitterOrientation.Vertical then alpha.x else alpha.y)
+		local newAlpha = if props.Orientation == Constants.SplitterOrientation.Vertical then alpha.x else alpha.y
+		if newAlpha ~= props.Alpha then
+			props.OnAlphaChanged(newAlpha)
+		end
 	end)
 
 	local mouseIconId = hooks.useValue(nil)

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -118,6 +118,7 @@ local function Splitter(props, hooks)
 			Size = size0,
 			BackgroundTransparency = 1,
 			ZIndex = 0,
+			ClipsDescendants = true,
 		}, { Content = props[Roact.Children][1] }),
 		Side1 = Roact.createElement("Frame", {
 			AnchorPoint = anchor1,
@@ -125,6 +126,7 @@ local function Splitter(props, hooks)
 			Size = size1,
 			BackgroundTransparency = 1,
 			ZIndex = 0,
+			ClipsDescendants = true,
 		}, { Content = props[Roact.Children][2] }),
 		Bar = Roact.createElement("TextButton", {
 			Active = false,

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -18,9 +18,9 @@ local defaultProps = {
 --[[
 TODO: 
 - figure out how (whether?) to do mouse icon
-- self-managed version?
-- make sure no perf concerns from re-rendering complex children (?)
+- is there a strategy for preventing child re-renders when the only thing that changed is the split?
 - make dragging still work when cursor is outside of a widget/background (getDragInput?)
+- self-managed version?
 ]]
 
 -- handles case where min is greater than max by prioritizing the min operation
@@ -103,14 +103,14 @@ local function Splitter(props, hooks)
 			Size = size0,
 			BackgroundTransparency = 1,
 			ZIndex = 0,
-		}, { props[Roact.Children][1] }),
+		}, { Content = props[Roact.Children][1] }),
 		Side1 = Roact.createElement("Frame", {
 			AnchorPoint = anchor1,
 			Position = position1,
 			Size = size1,
 			BackgroundTransparency = 1,
 			ZIndex = 0,
-		}, { props[Roact.Children][2] }),
+		}, { Content = props[Roact.Children][2] }),
 		Bar = Roact.createElement("TextButton", {
 			AutoButtonColor = false,
 			Text = "",

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -1,0 +1,126 @@
+local Packages = script.Parent.Parent
+
+local Roact = require(Packages.Roact)
+local Hooks = require(Packages.RoactHooks)
+
+local Constants = require(script.Parent.Constants)
+local useTheme = require(script.Parent.useTheme)
+
+local HANDLE_THICKNESS = 4
+
+local defaultProps = {
+	Size = UDim2.fromScale(1, 1),
+	MinAlpha = 0.05,
+	MaxAlpha = 0.95,
+	Orientation = Constants.SplitterOrientation.Vertical,
+}
+
+--[[
+TODO: 
+- figure out how (whether?) to do mouse icon
+- disabled?
+- self-managed version?
+- make sure no perf concerns from re-rendering complex children (?)
+- make dragging still work when cursor is outside of a widget/background (getDragInput?)
+]]
+
+-- handles case where min is greater than max by prioritizing the min operation
+local function safeClamp(value, min, max)
+	return math.min(math.max(value, min), max)
+end
+
+local function Splitter(props, hooks)
+	local theme = useTheme(hooks)
+	local dragging, setDragging = hooks.useState(false)
+
+	local onInputBegan = function(_, input)
+		if input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setDragging(true)
+		end
+	end
+
+	local onInputEnded = function(_, input)
+		if input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setDragging(false)
+		end
+	end
+
+	local onInputChanged = function(container, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			if dragging == true then
+				local size = container.AbsoluteSize
+				local offset = Vector2.new(input.Position.x, input.Position.y) - container.AbsolutePosition
+				offset = Vector2.new(
+					-- prevent handle escaping container
+					safeClamp(offset.x, HANDLE_THICKNESS + 1, size.x - HANDLE_THICKNESS - 1),
+					safeClamp(offset.y, HANDLE_THICKNESS + 1, size.y - HANDLE_THICKNESS - 1)
+				)
+				local relative = offset / size
+				local alpha = Vector2.new(
+					-- additionally clamp within min/max from props
+					safeClamp(relative.x, props.MinAlpha, props.MaxAlpha),
+					safeClamp(relative.y, props.MinAlpha, props.MaxAlpha)
+				)
+				props.OnAlphaChanged(
+					if props.Orientation == Constants.SplitterOrientation.Vertical then alpha.x else alpha.y
+				)
+			end
+		end
+	end
+
+	local size0 = UDim2.new(props.Alpha, -HANDLE_THICKNESS / 2, 1, 0)
+	local size1 = UDim2.new(1 - props.Alpha, -HANDLE_THICKNESS / 2, 1, 0)
+	local anchor1 = Vector2.new(1, 0)
+	local position1 = UDim2.fromScale(1, 0)
+	local barAnchorPoint = Vector2.new(0.5, 0)
+	local barPosition = UDim2.fromScale(props.Alpha, 0)
+	local barSize = UDim2.new(0, HANDLE_THICKNESS, 1, 0)
+	if props.Orientation == Constants.SplitterOrientation.Horizontal then
+		size0 = UDim2.new(size0.Height, size0.Width)
+		size1 = UDim2.new(size1.Height, size1.Width)
+		anchor1 = Vector2.new(anchor1.y, anchor1.x)
+		position1 = UDim2.new(position1.Height, position1.Width)
+		barAnchorPoint = Vector2.new(barAnchorPoint.y, barAnchorPoint.x)
+		barPosition = UDim2.new(barPosition.Height, barPosition.Width)
+		barSize = UDim2.new(barSize.Height, barSize.Width)
+	end
+
+	return Roact.createElement("Frame", {
+		Size = props.Size,
+		Position = props.Position,
+		AnchorPoint = props.AnchorPoint,
+		ZIndex = props.ZIndex,
+		LayoutOrder = props.LayoutOrder,
+		BackgroundTransparency = 1,
+		[Roact.Event.InputChanged] = onInputChanged,
+	}, {
+		Side0 = Roact.createElement("Frame", {
+			Size = size0,
+			BackgroundTransparency = 1,
+			ZIndex = 0,
+		}, { props[Roact.Children][1] }),
+		Side1 = Roact.createElement("Frame", {
+			AnchorPoint = anchor1,
+			Position = position1,
+			Size = size1,
+			BackgroundTransparency = 1,
+			ZIndex = 0,
+		}, { props[Roact.Children][2] }),
+		Bar = Roact.createElement("TextButton", {
+			AutoButtonColor = false,
+			Text = "",
+			AnchorPoint = barAnchorPoint,
+			Position = barPosition,
+			Size = barSize,
+			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.DialogButton),
+			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
+			ZIndex = 1,
+			[Roact.Event.InputBegan] = onInputBegan,
+			[Roact.Event.InputEnded] = onInputEnded,
+		}),
+	})
+end
+
+return Hooks.new(Roact)(Splitter, {
+	defaultProps = defaultProps,
+})

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -5,6 +5,7 @@ local Hooks = require(Packages.RoactHooks)
 
 local Constants = require(script.Parent.Constants)
 local useTheme = require(script.Parent.useTheme)
+local usePlugin = require(script.Parent.usePlugin)
 
 local HANDLE_THICKNESS = 4
 
@@ -17,9 +18,7 @@ local defaultProps = {
 
 --[[
 TODO: 
-- figure out how (whether?) to do mouse icon
 - is there a strategy for preventing child re-renders when the only thing that changed is the split?
-- make dragging still work when cursor is outside of a widget/background (getDragInput?)
 - self-managed version?
 ]]
 
@@ -30,55 +29,116 @@ end
 
 local function Splitter(props, hooks)
 	local theme = useTheme(hooks)
+	local plugin = usePlugin(hooks)
+
+	local hovered, setHovered = hooks.useState(false)
 	local dragging, setDragging = hooks.useState(false)
 
-	local onInputBegan = function(_, input)
-		if props.Disabled then
-			return
-		end
-		if input.UserInputType == Enum.UserInputType.MouseButton1 then
-			setDragging(true)
+	local mouseIconId = hooks.useValue(nil)
+	local mouseIconUsed = hooks.useValue(nil)
+	local containerRef = hooks.useValue(Roact.createRef())
+	local globalConnection = hooks.useValue(nil)
+
+	local function cleanup()
+		if globalConnection.value then
+			globalConnection.value:Disconnect()
 		end
 	end
 
-	local onInputEnded = function(_, input)
-		if input.UserInputType == Enum.UserInputType.MouseButton1 then
-			setDragging(false)
+	hooks.useEffect(function()
+		return cleanup
+	end, {}) -- mount -> unmount
+
+	hooks.useEffect(function()
+		if plugin ~= nil then
+			local active = hovered or dragging
+			local icon = string.format(
+				"rbxasset://SystemCursors/Split%s",
+				if props.Orientation == Constants.SplitterOrientation.Vertical then "EW" else "NS"
+			)
+			if active then
+				if not mouseIconId.value then
+					mouseIconId.value = plugin.pushMouseIcon(icon)
+				elseif mouseIconUsed.value ~= icon then
+					plugin.popMouseIcon(mouseIconId.value)
+					mouseIconId.value = plugin.pushMouseIcon(icon)
+				end
+				mouseIconUsed.value = icon
+			elseif not active and mouseIconId.value then
+				plugin.popMouseIcon(mouseIconId.value)
+				mouseIconId.value = nil
+				mouseIconUsed.value = nil
+			end
 		end
+	end, { plugin, hovered, dragging, props.Orientation })
+
+	local function process(position)
+		local container = containerRef.value:getValue()
+		local size = container.AbsoluteSize
+		local offset = Vector2.new(position.x, position.y) - container.AbsolutePosition
+		offset = Vector2.new(
+			-- prevent handle escaping container
+			safeClamp(offset.x, HANDLE_THICKNESS + 1, size.x - HANDLE_THICKNESS - 1),
+			safeClamp(offset.y, HANDLE_THICKNESS + 1, size.y - HANDLE_THICKNESS - 1)
+		)
+		local relative = offset / size
+		local alpha = Vector2.new(
+			-- additionally clamp within min/max from props
+			safeClamp(relative.x, props.MinAlpha, props.MaxAlpha),
+			safeClamp(relative.y, props.MinAlpha, props.MaxAlpha)
+		)
+		props.OnAlphaChanged(if props.Orientation == Constants.SplitterOrientation.Vertical then alpha.x else alpha.y)
 	end
 
-	local onInputChanged = function(container, input)
+	local onBarInputBegan = function(rbx, input)
 		if props.Disabled then
 			return
 		end
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
-			if dragging == true then
-				local size = container.AbsoluteSize
-				local offset = Vector2.new(input.Position.x, input.Position.y) - container.AbsolutePosition
-				offset = Vector2.new(
-					-- prevent handle escaping container
-					safeClamp(offset.x, HANDLE_THICKNESS + 1, size.x - HANDLE_THICKNESS - 1),
-					safeClamp(offset.y, HANDLE_THICKNESS + 1, size.y - HANDLE_THICKNESS - 1)
-				)
-				local relative = offset / size
-				local alpha = Vector2.new(
-					-- additionally clamp within min/max from props
-					safeClamp(relative.x, props.MinAlpha, props.MaxAlpha),
-					safeClamp(relative.y, props.MinAlpha, props.MaxAlpha)
-				)
-				props.OnAlphaChanged(
-					if props.Orientation == Constants.SplitterOrientation.Vertical then alpha.x else alpha.y
-				)
+			setHovered(true)
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setDragging(true)
+
+			local UserInputService = game:GetService("UserInputService")
+			local RunService = game:GetService("RunService")
+
+			local widget = rbx:FindFirstAncestorWhichIsA("DockWidgetPluginGui")
+			if widget ~= nil then
+				globalConnection.value = RunService.RenderStepped:Connect(function()
+					process(widget:GetRelativeMousePosition())
+				end)
+			else
+				globalConnection.value = UserInputService.InputChanged:Connect(function(globalInput)
+					process(Vector2.new(globalInput.Position.x, globalInput.Position.y))
+				end)
 			end
 		end
 	end
 
-	local size0 = UDim2.new(props.Alpha, -HANDLE_THICKNESS / 2, 1, 0)
-	local size1 = UDim2.new(1 - props.Alpha, -HANDLE_THICKNESS / 2, 1, 0)
+	local onBarInputEnded = function(rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			setHovered(false)
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+			setDragging(false)
+			-- ended for mousemovement does not fire if mouse is moved and released quickly enough
+			-- over another instance, so we set hover=false if mouse is no longer over it
+			local offset = Vector2.new(input.Position.x, input.Position.y) - rbx.AbsolutePosition
+			local bounds = rbx.AbsoluteSize
+			if offset.x < 0 or offset.x > bounds.x or offset.y < 0 or offset.y > bounds.y then
+				setHovered(false)
+			end
+			cleanup()
+		end
+	end
+
+	local alpha = safeClamp(props.Alpha, props.MinAlpha, props.MaxAlpha)
+
+	local size0 = UDim2.new(alpha, -HANDLE_THICKNESS / 2, 1, 0)
+	local size1 = UDim2.new(1 - alpha, -HANDLE_THICKNESS / 2, 1, 0)
 	local anchor1 = Vector2.new(1, 0)
 	local position1 = UDim2.fromScale(1, 0)
 	local barAnchorPoint = Vector2.new(0.5, 0)
-	local barPosition = UDim2.fromScale(props.Alpha, 0)
+	local barPosition = UDim2.fromScale(alpha, 0)
 	local barSize = UDim2.new(0, HANDLE_THICKNESS, 1, 0)
 	if props.Orientation == Constants.SplitterOrientation.Horizontal then
 		size0 = UDim2.new(size0.Height, size0.Width)
@@ -97,7 +157,7 @@ local function Splitter(props, hooks)
 		ZIndex = props.ZIndex,
 		LayoutOrder = props.LayoutOrder,
 		BackgroundTransparency = 1,
-		[Roact.Event.InputChanged] = onInputChanged,
+		[Roact.Ref] = containerRef.value,
 	}, {
 		Side0 = Roact.createElement("Frame", {
 			Size = size0,
@@ -112,6 +172,7 @@ local function Splitter(props, hooks)
 			ZIndex = 0,
 		}, { Content = props[Roact.Children][2] }),
 		Bar = Roact.createElement("TextButton", {
+			Active = false,
 			AutoButtonColor = false,
 			Text = "",
 			AnchorPoint = barAnchorPoint,
@@ -121,8 +182,8 @@ local function Splitter(props, hooks)
 			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
 			BackgroundTransparency = props.Disabled and 0.75 or 0,
 			ZIndex = 1,
-			[Roact.Event.InputBegan] = onInputBegan,
-			[Roact.Event.InputEnded] = onInputEnded,
+			[Roact.Event.InputBegan] = onBarInputBegan,
+			[Roact.Event.InputEnded] = onBarInputEnded,
 		}),
 	})
 end

--- a/src/Splitter.lua
+++ b/src/Splitter.lua
@@ -18,7 +18,6 @@ local defaultProps = {
 --[[
 TODO: 
 - figure out how (whether?) to do mouse icon
-- disabled?
 - self-managed version?
 - make sure no perf concerns from re-rendering complex children (?)
 - make dragging still work when cursor is outside of a widget/background (getDragInput?)
@@ -34,6 +33,9 @@ local function Splitter(props, hooks)
 	local dragging, setDragging = hooks.useState(false)
 
 	local onInputBegan = function(_, input)
+		if props.Disabled then
+			return
+		end
 		if input.UserInputType == Enum.UserInputType.MouseButton1 then
 			setDragging(true)
 		end
@@ -46,6 +48,9 @@ local function Splitter(props, hooks)
 	end
 
 	local onInputChanged = function(container, input)
+		if props.Disabled then
+			return
+		end
 		if input.UserInputType == Enum.UserInputType.MouseMovement then
 			if dragging == true then
 				local size = container.AbsoluteSize
@@ -114,6 +119,7 @@ local function Splitter(props, hooks)
 			Size = barSize,
 			BackgroundColor3 = theme:GetColor(Enum.StudioStyleGuideColor.DialogButton),
 			BorderColor3 = theme:GetColor(Enum.StudioStyleGuideColor.Border),
+			BackgroundTransparency = props.Disabled and 0.75 or 0,
 			ZIndex = 1,
 			[Roact.Event.InputBegan] = onInputBegan,
 			[Roact.Event.InputEnded] = onInputEnded,

--- a/src/Splitter.story.lua
+++ b/src/Splitter.story.lua
@@ -2,10 +2,13 @@ local Packages = script.Parent.Parent
 local Roact = require(Packages.Roact)
 
 local Constants = require(script.Parent.Constants)
-local Splitter = require(script.Parent.Splitter)
 
+local Splitter = require(script.Parent.Splitter)
 local PluginProvider = require(script.Parent.PluginProvider)
+
 local Label = require(script.Parent.Label)
+local ScrollFrame = require(script.Parent.ScrollFrame)
+local Dropdown = require(script.Parent.Dropdown)
 
 local Wrapper = Roact.Component:extend("Wrapper")
 
@@ -18,6 +21,15 @@ function Wrapper:init()
 end
 
 function Wrapper:render()
+	local scrollContents = {}
+	for i = 1, 20 do
+		scrollContents[i] = Roact.createElement(Label, {
+			Size = UDim2.new(1, 0, 0, 20),
+			Text = "Item " .. i,
+			LayoutOrder = i,
+		})
+	end
+
 	return Roact.createElement(Splitter, {
 		Alpha = self.state.Alpha0,
 		OnAlphaChanged = function(newAlpha)
@@ -25,10 +37,9 @@ function Wrapper:render()
 		end,
 		Orientation = Constants.SplitterOrientation.Vertical,
 	}, {
-		[1] = Roact.createElement(Label, {
+		[1] = Roact.createElement(ScrollFrame, {
 			Size = UDim2.fromScale(1, 1),
-			Text = "Side 1",
-		}),
+		}, scrollContents),
 		[2] = Roact.createElement(Splitter, {
 			Alpha = self.state.Alpha1,
 			OnAlphaChanged = function(newAlpha)
@@ -53,9 +64,13 @@ function Wrapper:render()
 					Text = "Side 2(1)(2)",
 				}),
 			}),
-			[2] = Roact.createElement(Label, {
-				Size = UDim2.fromScale(1, 1),
-				Text = "Side 2(2)",
+			[2] = Roact.createElement(Dropdown, {
+				AnchorPoint = Vector2.new(0.5, 0.5),
+				Position = UDim2.fromScale(0.5, 0.5),
+				Width = UDim.new(0.4, 50),
+				SelectedItem = "Test",
+				Items = { "Test", "Example", "Placeholder", "Dummy", "Sample" },
+				OnItemSelected = function() end,
 			}),
 		}),
 	})

--- a/src/Splitter.story.lua
+++ b/src/Splitter.story.lua
@@ -1,0 +1,55 @@
+local Packages = script.Parent.Parent
+local Roact = require(Packages.Roact)
+
+local Constants = require(script.Parent.Constants)
+local Splitter = require(script.Parent.Splitter)
+
+local Label = require(script.Parent.Label)
+
+local Wrapper = Roact.Component:extend("Wrapper")
+
+function Wrapper:init()
+	self:setState({
+		Alpha0 = 0.5,
+		Alpha1 = 0.5,
+	})
+end
+
+function Wrapper:render()
+	return Roact.createElement(Splitter, {
+		Alpha = self.state.Alpha0,
+		OnAlphaChanged = function(newAlpha)
+			self:setState({ Alpha0 = newAlpha })
+		end,
+		Orientation = Constants.SplitterOrientation.Vertical,
+	}, {
+		[1] = Roact.createElement(Label, {
+			Size = UDim2.fromScale(1, 1),
+			Text = "Side 1",
+		}),
+		[2] = Roact.createElement(Splitter, {
+			Alpha = self.state.Alpha1,
+			OnAlphaChanged = function(newAlpha)
+				self:setState({ Alpha1 = newAlpha })
+			end,
+			Orientation = Constants.SplitterOrientation.Horizontal,
+		}, {
+			[1] = Roact.createElement(Label, {
+				Size = UDim2.fromScale(1, 1),
+				Text = "Side 2(1)",
+			}),
+			[2] = Roact.createElement(Label, {
+				Size = UDim2.fromScale(1, 1),
+				Text = "Side 2(2)",
+			}),
+		}),
+	})
+end
+
+return function(target)
+	local element = Roact.createElement(Wrapper)
+	local handle = Roact.mount(element, target)
+	return function()
+		Roact.unmount(handle)
+	end
+end

--- a/src/Splitter.story.lua
+++ b/src/Splitter.story.lua
@@ -12,6 +12,7 @@ function Wrapper:init()
 	self:setState({
 		Alpha0 = 0.5,
 		Alpha1 = 0.5,
+		Alpha2 = 0.5,
 	})
 end
 
@@ -34,9 +35,22 @@ function Wrapper:render()
 			end,
 			Orientation = Constants.SplitterOrientation.Horizontal,
 		}, {
-			[1] = Roact.createElement(Label, {
-				Size = UDim2.fromScale(1, 1),
-				Text = "Side 2(1)",
+			[1] = Roact.createElement(Splitter, {
+				Alpha = self.state.Alpha2,
+				OnAlphaChanged = function(newAlpha)
+					self:setState({ Alpha2 = newAlpha })
+				end,
+				Orientation = Constants.SplitterOrientation.Vertical,
+				Disabled = true,
+			}, {
+				[1] = Roact.createElement(Label, {
+					Size = UDim2.fromScale(1, 1),
+					Text = "Side 2(1)(1)",
+				}),
+				[2] = Roact.createElement(Label, {
+					Size = UDim2.fromScale(1, 1),
+					Text = "Side 2(1)(2)",
+				}),
 			}),
 			[2] = Roact.createElement(Label, {
 				Size = UDim2.fromScale(1, 1),

--- a/src/Splitter.story.lua
+++ b/src/Splitter.story.lua
@@ -62,7 +62,8 @@ function Wrapper:render()
 end
 
 return function(target)
-	-- NB: hoarcekat does not provide a way to access its plugin instance
+	-- hoarcekat does not provide a way to access its plugin instance
+	-- this is a little hacky but acceptable since it's purely for the story
 	-- selene: allow(undefined_variable)
 	local plugin = PluginManager():CreatePlugin()
 	local element = Roact.createElement(PluginProvider, {

--- a/src/Splitter.story.lua
+++ b/src/Splitter.story.lua
@@ -4,6 +4,7 @@ local Roact = require(Packages.Roact)
 local Constants = require(script.Parent.Constants)
 local Splitter = require(script.Parent.Splitter)
 
+local PluginProvider = require(script.Parent.PluginProvider)
 local Label = require(script.Parent.Label)
 
 local Wrapper = Roact.Component:extend("Wrapper")
@@ -61,7 +62,14 @@ function Wrapper:render()
 end
 
 return function(target)
-	local element = Roact.createElement(Wrapper)
+	-- NB: hoarcekat does not provide a way to access its plugin instance
+	-- selene: allow(undefined_variable)
+	local plugin = PluginManager():CreatePlugin()
+	local element = Roact.createElement(PluginProvider, {
+		Plugin = plugin,
+	}, {
+		Main = Roact.createElement(Wrapper),
+	})
 	local handle = Roact.mount(element, target)
 	return function()
 		Roact.unmount(handle)

--- a/src/init.lua
+++ b/src/init.lua
@@ -21,4 +21,5 @@ return {
 
 	withTheme = require(script.withTheme),
 	useTheme = require(script.useTheme),
+	usePlugin = require(script.usePlugin),
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -15,7 +15,10 @@ return {
 	VerticalCollapsibleSection = require(script.VerticalCollapsibleSection),
 	VerticalExpandingList = require(script.VerticalExpandingList),
 	Widget = require(script.Widget),
+
 	ThemeContext = require(script.ThemeContext),
+	PluginProvider = require(script.PluginProvider),
+
 	withTheme = require(script.withTheme),
 	useTheme = require(script.useTheme),
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -8,6 +8,7 @@ return {
 	MainButton = require(script.MainButton),
 	ScrollFrame = require(script.ScrollFrame),
 	Slider = require(script.Slider),
+	Splitter = require(script.Splitter),
 	TabContainer = require(script.TabContainer),
 	TextInput = require(script.TextInput),
 	Tooltip = require(script.Tooltip),

--- a/src/useDragInput.lua
+++ b/src/useDragInput.lua
@@ -12,6 +12,12 @@ local function useDragInput(hooks, callback)
 		end
 	end
 
+	-- prevents stale callback values
+	local savedCallback = hooks.useValue(callback)
+	hooks.useEffect(function()
+		savedCallback.value = callback
+	end, { callback })
+
 	-- cleanup on unmount
 	hooks.useEffect(function()
 		return cleanup
@@ -24,15 +30,15 @@ local function useDragInput(hooks, callback)
 			local widget = rbx:FindFirstAncestorWhichIsA("DockWidgetPluginGui")
 			if widget ~= nil then
 				globalConnection.value = RunService.RenderStepped:Connect(function()
-					callback(rbx, widget:GetRelativeMousePosition())
+					savedCallback.value(rbx, widget:GetRelativeMousePosition())
 				end)
 			else
 				globalConnection.value = UserInputService.InputChanged:Connect(function(globalInput)
-					callback(rbx, Vector2.new(globalInput.Position.x, globalInput.Position.y))
+					savedCallback.value(rbx, Vector2.new(globalInput.Position.x, globalInput.Position.y))
 				end)
 			end
 			setDragging(true)
-			callback(rbx, Vector2.new(input.Position.x, input.Position.y))
+			savedCallback.value(rbx, Vector2.new(input.Position.x, input.Position.y))
 		end
 	end
 

--- a/src/useDragInput.lua
+++ b/src/useDragInput.lua
@@ -1,0 +1,61 @@
+local UserInputService = game:GetService("UserInputService")
+local RunService = game:GetService("RunService")
+
+local function useDragInput(hooks, callback)
+	local hovered, setHovered = hooks.useState(false)
+	local dragging, setDragging = hooks.useState(false)
+
+	local globalConnection = hooks.useValue(nil)
+	local function cleanup()
+		if globalConnection.value then
+			globalConnection.value:Disconnect()
+		end
+	end
+
+	hooks.useEffect(function()
+		return cleanup
+	end, {})
+
+	local onInputBegan = function(rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			setHovered(true)
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 and not dragging then
+			local widget = rbx:FindFirstAncestorWhichIsA("DockWidgetPluginGui")
+			if widget ~= nil then
+				globalConnection.value = RunService.RenderStepped:Connect(function()
+					callback(widget:GetRelativeMousePosition())
+				end)
+			else
+				globalConnection.value = UserInputService.InputChanged:Connect(function(globalInput)
+					callback(Vector2.new(globalInput.Position.x, globalInput.Position.y))
+				end)
+			end
+			setDragging(true)
+		end
+	end
+
+	local onInputEnded = function(rbx, input)
+		if input.UserInputType == Enum.UserInputType.MouseMovement then
+			setHovered(false)
+		elseif input.UserInputType == Enum.UserInputType.MouseButton1 then
+			-- ended for mousemovement does not fire if mouse is moved and released quickly enough
+			-- over another instance, so we manually check if there is still an active hover
+			local offset = Vector2.new(input.Position.x, input.Position.y) - rbx.AbsolutePosition
+			local bounds = rbx.AbsoluteSize
+			if offset.x < 0 or offset.x > bounds.x or offset.y < 0 or offset.y > bounds.y then
+				setHovered(false)
+			end
+			setDragging(false)
+			cleanup()
+		end
+	end
+
+	return {
+		hovered = hovered,
+		dragging = dragging,
+		onInputBegan = onInputBegan,
+		onInputEnded = onInputEnded,
+	}
+end
+
+return useDragInput

--- a/src/useDragInput.lua
+++ b/src/useDragInput.lua
@@ -12,6 +12,7 @@ local function useDragInput(hooks, callback)
 		end
 	end
 
+	-- cleanup on unmount
 	hooks.useEffect(function()
 		return cleanup
 	end, {})
@@ -23,14 +24,15 @@ local function useDragInput(hooks, callback)
 			local widget = rbx:FindFirstAncestorWhichIsA("DockWidgetPluginGui")
 			if widget ~= nil then
 				globalConnection.value = RunService.RenderStepped:Connect(function()
-					callback(widget:GetRelativeMousePosition())
+					callback(rbx, widget:GetRelativeMousePosition())
 				end)
 			else
 				globalConnection.value = UserInputService.InputChanged:Connect(function(globalInput)
-					callback(Vector2.new(globalInput.Position.x, globalInput.Position.y))
+					callback(rbx, Vector2.new(globalInput.Position.x, globalInput.Position.y))
 				end)
 			end
 			setDragging(true)
+			callback(rbx, Vector2.new(input.Position.x, input.Position.y))
 		end
 	end
 
@@ -50,11 +52,18 @@ local function useDragInput(hooks, callback)
 		end
 	end
 
+	local cancel = function()
+		setHovered(false)
+		setDragging(false)
+		cleanup()
+	end
+
 	return {
 		hovered = hovered,
 		dragging = dragging,
 		onInputBegan = onInputBegan,
 		onInputEnded = onInputEnded,
+		cancel = cancel,
 	}
 end
 

--- a/src/usePlugin.lua
+++ b/src/usePlugin.lua
@@ -1,0 +1,7 @@
+local PluginContext = require(script.Parent.PluginContext)
+
+local function usePlugin(hooks)
+	return hooks.useContext(PluginContext)
+end
+
+return usePlugin


### PR DESCRIPTION
This PR implements:
- Splitter component: region with two sub-panels and a draggable divider between them
- useDragInput hook: hookified replacement for getDragInput, incorporating some ideas from #22
- PluginProvider component: organized method to provide plugin api to consumers including Splitter, which uses a custom mouse icon stack api to handle / reconcile splitter mouse cursors
- usePlugin hook: consumer of a PluginProvider's context used as above

![image](https://user-images.githubusercontent.com/25118482/193143017-aafe29f3-b988-4b82-ad3e-a2433c54d2c2.png)
