### PR TITLE
Implement OnCompleted prop for Slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   Fixed image links in documentation
+-   Added OnCompleted prop to Slider
 
 ## 1.0.0
 

--- a/src/Components/NumericInput.luau
+++ b/src/Components/NumericInput.luau
@@ -20,6 +20,7 @@
 
 	Use the `Arrows` and `Slider` props to specify whether up/down arrows and a slider should be
 	included. If arrows or a slider are displayed, they will increment the value by the amount of the step. 
+	Completing a slide with a slider will call the `OnSubmitted` prop (if provided) with the latest value.
 	
 	Only decimal inputs are allowed (so, for example, hex characters a-f will not be permitted).
 ]=]
@@ -327,6 +328,7 @@ local function NumericInput(props: NumericInputProps)
 			Max = max,
 			Step = step,
 			OnChanged = props.OnValidChanged,
+			OnCompleted = props.OnSubmitted,
 			Disabled = props.Disabled,
 		}),
 	})

--- a/src/Components/Slider.luau
+++ b/src/Components/Slider.luau
@@ -30,6 +30,10 @@
 	end
 	```
 
+	Optionally, an `OnCompleted` callback prop can be provided. This will be called with the latest
+	value of the Slider when sliding is finished. It is also called if the component becomes Disabled
+	via props while a slide is in progress.
+
 	Two further props can optionally be provided:
 	1. `Border` determines whether a border is drawn around the component.
 	This is useful for giving visual feedback when the slider is hovered or selected. 
@@ -58,6 +62,7 @@ local useTheme = require("../Hooks/useTheme")
 	@field ... CommonProps
 	@field Value number
 	@field OnChanged ((newValue: number) -> ())?
+	@field OnCompleted ((newValue: number) -> ())?
 	@field Min number
 	@field Max number
 	@field Step number?
@@ -68,6 +73,7 @@ local useTheme = require("../Hooks/useTheme")
 type SliderProps = CommonProps.T & {
 	Value: number,
 	OnChanged: ((newValue: number) -> ())?,
+	OnCompleted: ((newValue: number) -> ())?,
 	Min: number,
 	Max: number,
 	Step: number?,
@@ -86,7 +92,7 @@ local function Slider(props: SliderProps)
 
 	local onChanged: (number) -> () = props.OnChanged or function() end
 
-	local drag = useMouseDrag(function(rbx: GuiObject, input: InputObject)
+	local dragCallback = function(rbx: GuiObject, input: InputObject)
 		local regionPos = rbx.AbsolutePosition.X + PADDING_REGION_SIDE
 		local regionSize = rbx.AbsoluteSize.X - PADDING_REGION_SIDE * 2
 		local inputPos = input.Position.X
@@ -102,7 +108,16 @@ local function Slider(props: SliderProps)
 		if value ~= props.Value then
 			onChanged(value)
 		end
-	end, { props.Value, props.Min, props.Max, props.Step, onChanged } :: { unknown })
+	end
+
+	local dragEndedCallback = function()
+		if props.OnCompleted then
+			props.OnCompleted(props.Value)
+		end
+	end
+
+	local dragDeps = { props.Value, props.Min, props.Max, props.Step, props.OnCompleted, onChanged } :: { unknown }
+	local drag = useMouseDrag(dragCallback, dragDeps, nil, dragEndedCallback)
 
 	local hovered, setHovered = React.useState(false)
 	local mainModifier = Enum.StudioStyleGuideModifier.Default

--- a/src/Components/Slider.luau
+++ b/src/Components/Slider.luau
@@ -31,8 +31,8 @@
 	```
 
 	Optionally, an `OnCompleted` callback prop can be provided. This will be called with the latest
-	value of the Slider when sliding is finished. It is also called if the component becomes Disabled
-	via props while a slide is in progress.
+	value of the Slider when sliding is finished. It is also called if, while sliding is in progress,
+	the component becomes Disabled via props or is unmounted.
 
 	Two further props can optionally be provided:
 	1. `Border` determines whether a border is drawn around the component.
@@ -51,6 +51,8 @@ local React = require("@pkg/@jsdotlua/react")
 
 local CommonProps = require("../CommonProps")
 local Constants = require("../Constants")
+
+local useFreshCallback = require("../Hooks/useFreshCallback")
 local useMouseDrag = require("../Hooks/useMouseDrag")
 local useTheme = require("../Hooks/useTheme")
 
@@ -110,11 +112,11 @@ local function Slider(props: SliderProps)
 		end
 	end
 
-	local dragEndedCallback = function()
+	local dragEndedCallback = useFreshCallback(function()
 		if props.OnCompleted then
 			props.OnCompleted(props.Value)
 		end
-	end
+	end, { props.Value, props.OnCompleted } :: { unknown })
 
 	local dragDeps = { props.Value, props.Min, props.Max, props.Step, props.OnCompleted, onChanged } :: { unknown }
 	local drag = useMouseDrag(dragCallback, dragDeps, nil, dragEndedCallback)

--- a/src/Hooks/useMouseDrag.luau
+++ b/src/Hooks/useMouseDrag.luau
@@ -40,7 +40,7 @@ local function useMouseDrag(
 			moveConnection.current:Disconnect()
 			moveConnection.current = nil
 		end
-		if onEndedCallback then
+		if onEndedCallback and holding.current == true then
 			onEndedCallback()
 		end
 	end


### PR DESCRIPTION
This PR adds an `OnCompleted` callback prop to Slider which is called with the most recent slider value when sliding is finished. It is also called when, during sliding, the component becomes Disabled via props or is unmounted. NumericInput has also been updated to pass its `OnSubmitted` callback prop through to the companion Slider's `OnCompleted` prop when specified.

Closes #45


