### PR TITLE
Add usePlugin hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-   Add usePlugin hook
+
 ## 1.1.0
 
 -   Fixed image links in documentation

--- a/moonwave.toml
+++ b/moonwave.toml
@@ -27,4 +27,4 @@ classes = ["Background", "Button", "Checkbox", "ColorPicker", "DatePicker", "Dro
 [[classOrder]]
 section = "Hooks"
 collapsed = false
-classes = ["useMouseIcon", "useTheme"]
+classes = ["useMouseIcon", "useTheme", "usePlugin"]

--- a/src/Hooks/usePlugin.luau
+++ b/src/Hooks/usePlugin.luau
@@ -1,0 +1,10 @@
+local React = require("@pkg/@jsdotlua/react")
+
+local PluginContext = require("../Contexts/PluginContext")
+
+local function usePlugin()
+	local pluginContext = React.useContext(PluginContext)
+	return pluginContext and pluginContext.plugin
+end
+
+return usePlugin

--- a/src/Hooks/usePlugin.luau
+++ b/src/Hooks/usePlugin.luau
@@ -1,3 +1,18 @@
+--[=[
+	@class usePlugin
+	
+	A hook used to obtain a reference to the root [plugin](https://create.roblox.com/docs/reference/engine/classes/Plugin)
+	instance associated with the current plugin. It requires a single [PluginProvider] to be present 
+	higher up in the tree.
+
+	```lua
+	local function MyComponent()
+		local plugin = usePlugin()
+		...
+	end
+	```
+]=]
+
 local React = require("@pkg/@jsdotlua/react")
 
 local PluginContext = require("../Contexts/PluginContext")

--- a/src/init.luau
+++ b/src/init.luau
@@ -23,6 +23,7 @@ return {
 	TextInput = require("./Components/TextInput"),
 
 	ThemeContext = require("./Contexts/ThemeContext"),
+	PluginContext = require("./Contexts/PluginContext"),
 
 	useTheme = require("./Hooks/useTheme"),
 	useMouseIcon = require("./Hooks/useMouseIcon"),

--- a/src/init.luau
+++ b/src/init.luau
@@ -23,8 +23,8 @@ return {
 	TextInput = require("./Components/TextInput"),
 
 	ThemeContext = require("./Contexts/ThemeContext"),
-	PluginContext = require("./Contexts/PluginContext"),
 
 	useTheme = require("./Hooks/useTheme"),
+	usePlugin = require("./Hooks/usePlugin"),
 	useMouseIcon = require("./Hooks/useMouseIcon"),
 }


### PR DESCRIPTION
This PR adds a new hook which provides the plugin value passed to the plugin provider.

I suppose you could write your own context and access it that way, but I feel as though this is much more convenient. That said, maybe you have a specific reason or opinion on keeping this private?