### PR TITLE
Add optional `DisplayTitle` prop for `TabContainer` tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Added an optional `DisplayTitle` prop to `TabContainer` children tabs to allow tabs to depend on some state for its display text
+- Added an optional `DisplayTitle` prop to `TabContainer` children tabs to allow displaying custom text on tabs
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+- Added an optional `DisplayTitle` prop to `TabContainer` children tabs to allow tabs to depend on some state for its display text
+
 ## 1.2.0
 
 -   Added usePlugin hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0
+## Unreleased
 - Added an optional `DisplayTitle` prop to `TabContainer` children tabs to allow tabs to depend on some state for its display text
 
 ## 1.2.0

--- a/src/Components/TabContainer.luau
+++ b/src/Components/TabContainer.luau
@@ -43,7 +43,7 @@
 		comments: { string } 
 	})
 		local selectedTab, setSelectedTab = React.useState("Comments")
-		local comments = #props.comments
+		local commentsArray = props.comments
 
 		return React.createElement(TabContainer, {
 			SelectedTab = selectedTab,

--- a/src/Components/TabContainer.luau
+++ b/src/Components/TabContainer.luau
@@ -36,6 +36,32 @@
 	end
 	```
 
+	For situations where the tab's display title may change depending on some state, you
+	can use the `DisplayTitle` prop within each `TabContainer` child:
+	```lua
+	local function MyListComponent(props: { 
+		comments: { string } 
+	})
+		local selectedTab, setSelectedTab = React.useState("Comments")
+		local comments = #props.comments
+
+		return React.createElement(TabContainer, {
+			SelectedTab = selectedTab,
+			OnTabSelected = setSelectedTab,
+		}, {
+			["Comments"] = {
+				LayoutOrder = 1,
+				DisplayTitle = `Comments ({#commentsArray})`,
+				Content = React.createElement(...),
+			},
+			["Settings"] = {
+				LayoutOrder = 2,
+				Content = React.createElement(...),
+			}
+		})
+	end
+	```
+
 	As well as disabling the entire component via the `Disabled` [CommonProp](CommonProps), individual
 	tabs can be disabled and made unselectable by passing `Disabled` with a value of `true` inside
 	the tab's entry in the `Tabs` prop table.
@@ -60,6 +86,7 @@ local TAB_HEIGHT = 30
 	@interface Tab
 
 	@field LayoutOrder number
+	@field DisplayTitle string?
 	@field Content React.ReactNode
 	@field Disabled boolean?
 ]=]
@@ -67,6 +94,7 @@ local TAB_HEIGHT = 30
 type Tab = {
 	Content: React.ReactNode,
 	LayoutOrder: number,
+	DisplayTitle: string?,
 	Disabled: boolean?,
 }
 
@@ -185,7 +213,7 @@ local function TabContainer(props: TabContainerProps)
 		tabs[name] = React.createElement(TabButton, {
 			Size = UDim2.fromScale(1 / count, 1),
 			LayoutOrder = tab.LayoutOrder,
-			Text = name,
+			Text = tab.DisplayTitle or name,
 			Selected = isSelectedTab,
 			Disabled = tab.Disabled == true or props.Disabled == true,
 			OnActivated = function()

--- a/src/Components/TabContainer.luau
+++ b/src/Components/TabContainer.luau
@@ -36,8 +36,8 @@
 	end
 	```
 
-	For situations where the tab's display title may change depending on some state, you
-	can use the `DisplayTitle` prop within each `TabContainer` child:
+	To override the text displayed on a tab, assign a value to the optional 
+	`DisplayTitle` field in the tab entry; see the "Comments" example below:
 	```lua
 	local function MyPluginApp(props: { 
 		comments: { string } 

--- a/src/Components/TabContainer.luau
+++ b/src/Components/TabContainer.luau
@@ -39,7 +39,7 @@
 	For situations where the tab's display title may change depending on some state, you
 	can use the `DisplayTitle` prop within each `TabContainer` child:
 	```lua
-	local function MyListComponent(props: { 
+	local function MyPluginApp(props: { 
 		comments: { string } 
 	})
 		local selectedTab, setSelectedTab = React.useState("Comments")


### PR DESCRIPTION
While working on a plugin I needed a tab within a `TabContainer` to change its text dynamically based on some state. This is not easy to do at the moment with `TabContainer` and would involve juggling key names and making sure the currently selected tab state is updated to match the new key name whenever your tab would depend on some state to define its display text.

I've added a `DisplayTitle` prop to the `TabContainer` children tabs which will be checked for before resorting to using the child key as the display title. No changes have been made to the key being used as the identifer that is passed to `OnTabSelected`.

- [x] add entry to the changelog
